### PR TITLE
Fix event error tests and clean repo

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -120,4 +120,3 @@ def parse_event(data: Dict[str, Any]) -> Event:
         target_node_id=target_node_id_val,
         label=label_val
     )
-```

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -194,5 +194,7 @@ class MockGraph(IGraphAdapter):
             "edges" maps to a list of all edges, where each edge is a tuple
             (source_node_id, target_node_id, label).
         """
-        return {"nodes": self._nodes.copy(), "edges": list(self._edges)}
-```
+        return {
+            "nodes": {nid: attrs.copy() for nid, attrs in self._nodes.items()},
+            "edges": list(self._edges),
+        }

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -186,4 +186,3 @@ class IGraphAdapter(ABC):
                                         or if nodes do not exist (implementation dependent).
         """
         pass
-```

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -117,4 +117,3 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
         graph._edges = loaded_edges # Direct assignment after validation
 
     return graph
-```

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -2,7 +2,8 @@
 import subprocess
 import sys
 import os
-import pytest # For tmp_path if needed later, and general test structure
+import shlex
+import pytest  # For tmp_path if needed later, and general test structure
 
 # Determine the absolute path to ume_cli.py
 # Assuming tests are run from the project root or a similar consistent location.
@@ -144,4 +145,3 @@ def test_cli_unknown_command(tmp_path): # tmp_path not used but is a standard fi
     assert "*** Unknown syntax: unknown_command_test" in stdout # Default Cmd behavior
     assert stderr == ""
 
-```

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -75,16 +75,16 @@ def test_parse_event_valid_edge_events(event_type: str, extra_data: dict):
     "bad_input, expected_message_part",
     [
         # Case 1: Missing all required fields
-        ({}, "Missing required event fields"),
+        ({}, "Missing required event field: event_type"),
 
         # Case 2: Missing 'event_type'
-        ({"timestamp": 123, "payload": {}}, "Missing required event fields: event_type"),
+        ({"timestamp": 123, "payload": {}}, "Missing required event field: event_type"),
 
         # Case 3: Missing 'timestamp'
-        ({"event_type": "test", "payload": {}}, "Missing required event fields: timestamp"),
+        ({"event_type": "test", "payload": {}}, "Missing required event field: timestamp"),
 
-        # Case 4: Missing 'payload'
-        ({"event_type": "test", "timestamp": 123}, "Missing required event fields: payload"),
+        # Case 4: Missing 'payload' for CREATE_NODE
+        ({"event_type": "CREATE_NODE", "timestamp": 123, "node_id": "n1"}, "Missing required field 'payload' for CREATE_NODE event."),
 
         # Case 5: Invalid type for 'event_type' (int instead of str)
         ({"event_type": 123, "timestamp": int(time.time()), "payload": {}}, "Invalid type for 'event_type'"),
@@ -93,13 +93,7 @@ def test_parse_event_valid_edge_events(event_type: str, extra_data: dict):
         ({"event_type": "test", "timestamp": "not-an-int", "payload": {}}, "Invalid type for 'timestamp'"),
 
         # Case 7: Invalid type for 'payload' (str instead of dict)
-        # This test case assumes event_type is "test", which is not "CREATE_NODE" or "UPDATE_NODE_ATTRIBUTES".
-        # For these specific node event types, payload is required. For "test", it's not strictly required by parse_event top-level.
-        # The new logic in parse_event defaults payload to {} and then checks its type if present for specific event types.
-        # If event_type is "CREATE_NODE" and payload is "not-a-dict", it will fail.
-        # Let's refine this test case for a node event type specifically if payload type is the main concern.
-        # The original test case is fine as a generic test where 'payload' is provided with wrong type.
-        ({"event_type": "test_payload_type", "timestamp": int(time.time()), "payload": "not-a-dict"}, "Invalid type for 'payload' in test_payload_type event (if provided): expected dict"),
+        ({"event_type": "CREATE_EDGE", "timestamp": int(time.time()), "node_id": "s1", "target_node_id": "t1", "label": "L", "payload": "not-a-dict"}, "Invalid type for 'payload' in CREATE_EDGE event (if provided): expected dict"),
 
         # New cases for CREATE_EDGE
         # CREATE_EDGE missing target_node_id

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,8 @@
 # tests/test_graph.py
 import pytest
-from ume import MockGraph, ProcessingError # IGraphAdapter is implicitly tested by testing MockGraph's adherence
-from ume.graph_adapter import IGraphAdapter # Import for isinstance check if needed
+import re
+from ume import MockGraph, ProcessingError  # IGraphAdapter is implicitly tested by testing MockGraph's adherence
+from ume.graph_adapter import IGraphAdapter  # Import for isinstance check if needed
 
 # Fixture for a clean MockGraph instance
 @pytest.fixture
@@ -296,7 +297,8 @@ def test_delete_edge_non_existent_raises_error(graph: MockGraph):
     # Edge ("s1", "t1", "DOES_NOT_EXIST") is never added
 
     edge_tuple = ("s1", "t1", "DOES_NOT_EXIST")
-    with pytest.raises(ProcessingError, match=f"Edge {edge_tuple} does not exist and cannot be deleted."):
+    expected = re.escape(f"Edge {edge_tuple} does not exist and cannot be deleted.")
+    with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
 
 def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph):
@@ -307,7 +309,8 @@ def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph)
     """
     graph.add_node("t1", {})
     edge_tuple = ("s_missing", "t1", "LINKS_TO")
-    with pytest.raises(ProcessingError, match=f"Edge {edge_tuple} does not exist and cannot be deleted."):
+    expected = re.escape(f"Edge {edge_tuple} does not exist and cannot be deleted.")
+    with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
 
 def test_delete_edge_non_existent_target_node_implicitly_fails(graph: MockGraph):
@@ -317,7 +320,7 @@ def test_delete_edge_non_existent_target_node_implicitly_fails(graph: MockGraph)
     """
     graph.add_node("s1", {})
     edge_tuple = ("s1", "t_missing", "LINKS_TO")
-    with pytest.raises(ProcessingError, match=f"Edge {edge_tuple} does not exist and cannot be deleted."):
+    expected = re.escape(f"Edge {edge_tuple} does not exist and cannot be deleted.")
+    with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
 
-```

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -159,16 +159,11 @@ def test_snapshot_file_content_is_pretty_printed(tmp_path: pathlib.Path):
         content = f.read()
 
     # Check for newlines and spaces indicative of pretty-printing (indent=2)
-    assert '
-  "' in content # Check for typical indentation
-    assert '{
-  "nodes": {
-    "node1": {
-' in content or            '{
-  "nodes": {
-      "node1": {
-' in content # Allow for slight variations
-```
+    assert '\n  "' in content  # Check for typical indentation (newline then spaces before a quote)
+    assert (
+        '{\n  "nodes": {\n    "node1": {' in content
+        or '{\n  "nodes": {\n      "node1": {' in content
+    )  # Allow for slight variations
 
 # --- Tests for load_graph_from_file ---
 
@@ -302,4 +297,3 @@ def test_load_graph_from_file_invalid_structure_edge_element_not_string(tmp_path
 
     with pytest.raises(SnapshotError, match="Invalid snapshot format for edge at index 0: all edge elements .* must be strings"):
         load_graph_from_file(snapshot_file)
-```

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,6 +1,7 @@
 # tests/test_processing.py
 import pytest
 import time
+import re
 from ume import Event, MockGraph, apply_event_to_graph, ProcessingError
 
 @pytest.fixture
@@ -92,7 +93,7 @@ def test_apply_update_node_attributes_node_not_exists(graph: MockGraph):
         timestamp=int(time.time()),
         payload={"node_id": node_id, "attributes": {"name": "Updated Name"}}
     )
-    with pytest.raises(ProcessingError, match=f"Node '{node_id}' does not exist"):
+    with pytest.raises(ProcessingError, match=re.escape(f"Node '{node_id}' not found for update.")):
         apply_event_to_graph(event, graph)
 
 def test_apply_update_node_attributes_missing_node_id(graph: MockGraph):
@@ -287,7 +288,8 @@ def test_apply_delete_edge_event_edge_not_exist(graph: MockGraph):
         payload={}
     )
     edge_tuple = ("s_node", "t_node", "NON_EXISTENT")
-    with pytest.raises(ProcessingError, match=f"Edge {edge_tuple} does not exist and cannot be deleted."):
+    expected = re.escape(f"Edge {edge_tuple} does not exist and cannot be deleted.")
+    with pytest.raises(ProcessingError, match=expected):
         apply_event_to_graph(event, graph)
 
 def test_apply_delete_edge_event_invalid_field_types_propagates_error(graph: MockGraph):

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -43,8 +43,8 @@ class UMEPrompt(Cmd):
             event_data = {
                 "event_type": "CREATE_NODE",
                 "node_id": node_id,
-                "payload": attributes, # Changed from "attributes" to "payload" to match Event dataclass
-                "timestamp": self._get_timestamp()
+                "payload": {"node_id": node_id, "attributes": attributes},
+                "timestamp": self._get_timestamp(),
             }
             evt = parse_event(event_data)
             apply_event_to_graph(evt, self.graph)
@@ -259,4 +259,3 @@ class UMEPrompt(Cmd):
 if __name__ == "__main__":
     UMEPrompt().cmdloop()
 
-```


### PR DESCRIPTION
## Summary
- align `tests/test_event.py` expected messages with `parse_event` errors
- fix CLI smoke tests by importing `shlex` and correcting `CREATE_NODE` payload
- ensure graph dumps return deep copies of node attributes
- escape regex patterns in graph and processing tests
- remove stray code block markers from sources

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9248a4a08326bb9bf1ae56dce19e