### PR TITLE
Implement cleanup and CLI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ poetry install --with dev
     ```bash
     poetry run pytest
     ```
+    Alternatively, run pytest directly by setting ``PYTHONPATH`` so the
+    source directory is discoverable (Python 3.12 or newer is required):
+    ```bash
+    PYTHONPATH=src pytest
+    ```
 
 2.  **Run tests with coverage report:**
     To run tests and generate a code coverage report for the `src/ume` package, use:
@@ -177,7 +182,7 @@ Strive for clear, concise tests that verify specific behaviors and edge cases.
 ## Quickstart
 
 ### Prerequisites
-- Python 3.9+
+- Python 3.12+
 - Poetry (https://python-poetry.org)
 - Docker & Docker Compose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pytest-cov = "*"
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"
+ume-cli = "ume_cli:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -10,11 +10,7 @@ from typing import Dict, Any, Optional
 # For now, let's assume a generic Exception in docstring, but implementations
 # like MockGraph will use ProcessingError from ume.processing.
 # Alternatively, we could forward declare ProcessingError if it's complex.
-# Let's try importing it under TYPE_CHECKING for now.
 
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from .processing import ProcessingError # Used in docstrings, implementations will raise it
 
 class IGraphAdapter(ABC):
     """

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -79,6 +79,9 @@ def apply_event_to_graph(event: Event, graph: IGraphAdapter) -> None:
                 f"Invalid event structure for CREATE_EDGE: source_node_id (event.node_id), target_node_id, "
                 f"and label must be strings and present. Event ID: {event.event_id}"
             )
+        assert isinstance(source_node_id, str)
+        assert isinstance(target_node_id, str)
+        assert isinstance(label, str)
         graph.add_edge(source_node_id, target_node_id, label)
 
     elif event.event_type == "DELETE_EDGE":
@@ -93,6 +96,9 @@ def apply_event_to_graph(event: Event, graph: IGraphAdapter) -> None:
                 f"Invalid event structure for DELETE_EDGE: source_node_id (event.node_id), target_node_id, "
                 f"and label must be strings and present. Event ID: {event.event_id}"
             )
+        assert isinstance(source_node_id, str)
+        assert isinstance(target_node_id, str)
+        assert isinstance(label, str)
         graph.delete_edge(source_node_id, target_node_id, label)
 
     else:

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -1,6 +1,6 @@
 # src/ume/snapshot.py
 import json
-from typing import Union, TYPE_CHECKING, Dict, Any, List, Tuple # Added List, Tuple
+from typing import Union, TYPE_CHECKING, List, Tuple
 import pathlib # For type hinting path-like objects
 
 # Ensure MockGraph is available for instantiation and type hinting
@@ -19,8 +19,8 @@ def snapshot_graph_to_file(graph: MockGraph, path: Union[str, pathlib.Path]) -> 
     """
     Snapshots the given MockGraph's current state to a JSON file.
 
-    The snapshot will include the data returned by graph.dump(), which
-    currently consists of nodes. The JSON file is pretty-printed with an
+    The snapshot includes the data returned by ``graph.dump()``, which
+    contains both nodes and edges. The JSON file is pretty-printed with an
     indent of 2 spaces.
 
     Args:

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -256,6 +256,11 @@ class UMEPrompt(Cmd):
     # def do_help(self, arg):
     #    Cmd.do_help(self, arg)
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for the ``ume-cli`` console script."""
     UMEPrompt().cmdloop()
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- remove unused imports
- assert str types for edge operations
- expose `ume-cli` via Poetry
- update README with Python 3.12+ and testing notes
- improve snapshot docstring

## Testing
- `ruff check .`
- `mypy src/ume`
- `PYTHONPATH=src pytest -q`
- `poetry run ume-cli --help`

------
https://chatgpt.com/codex/tasks/task_e_683f9a52aed483268318029293f4b45e