### PR TITLE
Remove duplicate invalid snapshot test

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -175,15 +175,3 @@ def test_cli_snapshot_load_invalid_snapshot(tmp_path):
     assert rc == 0
 
 
-def test_cli_snapshot_load_invalid_snapshot(tmp_path):
-    """Loading a malformed snapshot should print a user-friendly error."""
-    bad_snapshot = tmp_path / "bad_snapshot.json"
-    # Write an invalid snapshot (nodes should be a dict)
-    bad_snapshot.write_text('{"nodes": []}')
-
-    commands = [f"snapshot_load {shlex.quote(str(bad_snapshot))}", "exit"]
-    stdout, stderr = run_cli_commands(commands)
-
-    assert "Error loading snapshot" in stdout
-    assert stderr == ""
-


### PR DESCRIPTION
## Summary
- clean up `test_cli_snapshot_load_invalid_snapshot` in `tests/test_cli_smoke.py`
- keep the original definition and drop the duplicate

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840acb39df48326b605b93308a9281a