### PR TITLE
Implement persistent graph and auto snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+ume_graph.db
+ume_snapshot.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (though currently in pre-release/development phase).
+
+## [0.4.0-dev] - 2025-06-09
+### Added
+-   `PersistentGraph` SQLite-backed adapter replacing the in-memory `MockGraph`.
+-   Automatic graph snapshotting utilities and CLI integration.
+-   Documentation describing the immutable `ume_demo` event log.
+
+### Changed
+-   CLI and tests now use `PersistentGraph` by default.
+-   README updated to reflect automatic persistence.
 
 ## [0.3.0-dev] - 2023-10-27
 
@@ -120,7 +131,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Known Issues / Limitations (as of this version)
 
 -   Full end-to-end testing of demo scripts involving Kafka/Redpanda was blocked by environmental issues preventing `confluent-kafka` installation in the test execution environment. Unit tests for core logic are passing.
--   `MockGraph` now includes basic support for directed, labeled edges (storage, retrieval, and inclusion in snapshots). Advanced edge querying or property support is future work.
--   Graph persistence is limited to manual snapshotting of `MockGraph` to a file; no automated persistence or database backend yet.
+-   `PersistentGraph` provides only basic edge support; advanced queries and properties remain future work.
 
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The current system consists of the following main components:
     *   Redpanda is a Kafka-compatible streaming data platform. It is run locally using Docker, as defined in the `docker/docker-compose.yml` file.
     *   It receives events from producers and stores them durably in topics.
     *   It allows multiple consumers to subscribe to these topics and read events.
-    *   The demo uses a topic named `ume_demo`.
+    *   The demo uses a topic named `ume_demo`, configured for unlimited retention so it serves as an immutable event log.
     *   The Docker setup also includes Redpanda Console, which provides a UI and schema registry capabilities, accessible typically on `localhost:8081` (for the console) while Redpanda itself exposes a schema registry via Pandaproxy on `localhost:8082`.
 
 3.  **Event Consumer (`src/ume/consumer_demo.py`):**
@@ -126,7 +126,7 @@ This setup demonstrates a simple event-driven architecture, which is foundationa
 A core aspect of the Universal Memory Engine (UME) is its ability to construct a knowledge graph from the events it processes. This graph serves as the dynamic, queryable memory for agents and automations.
 
 The detailed schema of this graph, including node types, relationship types, and their properties, is a key part of UME's design. As the system evolves, this will be critical for understanding how memory is structured and utilized.
-Additionally, the graph supports directed, labeled **edges** connecting these nodes, representing relationships such as `(source_node_id, target_node_id, 'RELATES_TO')`. Internally, the `MockGraph` stores edges in an adjacency dictionary for faster lookup, while still exposing them as a list of tuples via `get_all_edges()`.
+Additionally, the graph supports directed, labeled **edges** connecting these nodes, representing relationships such as `(source_node_id, target_node_id, 'RELATES_TO')`. The default implementation, `PersistentGraph`, stores this data in a lightweight SQLite database for durability while still exposing edges as a list of tuples via `get_all_edges()`.
 
 For current plans and eventual detailed documentation on the UME graph model, please see:
 
@@ -236,11 +236,11 @@ PYTHONPATH=src pytest
 This section outlines the basic programmatic steps to interact with the UME components using an event-driven approach. Assumes project setup is complete and services (like Redpanda, if using network-based events) are running.
 
 1.  **Obtain a Graph Adapter Instance:**
-    Choose an implementation of `IGraphAdapter`. For local testing or simple use cases, `MockGraph` can be used:
+    The default adapter is `PersistentGraph`, which stores data in an SQLite database:
     ```python
-    from ume import MockGraph, IGraphAdapter
+    from ume import PersistentGraph, IGraphAdapter
 
-    graph_adapter: IGraphAdapter = MockGraph()
+    graph_adapter: IGraphAdapter = PersistentGraph("memory.db")
     ```
 
 2.  **Define Event Data Dictionaries:**
@@ -328,7 +328,7 @@ This section outlines the basic programmatic steps to interact with the UME comp
     ```
 
 5.  **Snapshot Graph to File (Optional):**
-    Persist the graph's state to a file:
+    The `PersistentGraph` persists automatically, but you can manually dump the graph to a JSON file:
     ```python
     from ume import snapshot_graph_to_file
     # import pathlib # Ensure pathlib is imported if using Path objects for snapshot_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ume"
-version = "0.3.0-dev"
+version = "0.4.0-dev"
 description = ""
 authors = ["Ume Bot <ume-bot@example.com>"]
 readme = "README.md"

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -3,16 +3,26 @@ Universal Memory Engine (UME) core package.
 """
 from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
+from .persistent_graph import PersistentGraph
+from .auto_snapshot import enable_periodic_snapshot
 from .graph_adapter import IGraphAdapter
 from .processing import apply_event_to_graph, ProcessingError
-from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError
+from .snapshot import (
+    snapshot_graph_to_file,
+    load_graph_from_file,
+    load_graph_into_existing,
+    SnapshotError,
+)
 
 __all__ = [
     "Event", "EventType", "parse_event", "EventError",
     "MockGraph",
+    "PersistentGraph",
+    "enable_periodic_snapshot",
     "IGraphAdapter",
     "apply_event_to_graph", "ProcessingError",
     "snapshot_graph_to_file",
     "load_graph_from_file",
+    "load_graph_into_existing",
     "SnapshotError"
 ]

--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -1,0 +1,24 @@
+import atexit
+import threading
+import time
+from pathlib import Path
+from typing import Union
+from .graph_adapter import IGraphAdapter
+from .snapshot import snapshot_graph_to_file
+
+
+def enable_periodic_snapshot(graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600) -> None:
+    """Enable periodic snapshotting and snapshot on shutdown."""
+    snapshot_path = Path(path)
+
+    def _snapshot() -> None:
+        snapshot_graph_to_file(graph, snapshot_path)
+
+    def _run() -> None:
+        while True:
+            time.sleep(interval_seconds)
+            _snapshot()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    atexit.register(_snapshot)

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -1,0 +1,126 @@
+import sqlite3
+import json
+from typing import Dict, Any, Optional, List, Tuple
+from .graph_adapter import IGraphAdapter
+from .processing import ProcessingError
+
+class PersistentGraph(IGraphAdapter):
+    """SQLite-backed persistent graph implementation."""
+
+    def __init__(self, db_path: str = "ume_graph.db") -> None:
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                "CREATE TABLE IF NOT EXISTS nodes (id TEXT PRIMARY KEY, attributes TEXT)"
+            )
+            self.conn.execute(
+                "CREATE TABLE IF NOT EXISTS edges (source TEXT, target TEXT, label TEXT, PRIMARY KEY (source, target, label))"
+            )
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        try:
+            with self.conn:
+                self.conn.execute(
+                    "INSERT INTO nodes(id, attributes) VALUES(?, ?)",
+                    (node_id, json.dumps(attributes)),
+                )
+        except sqlite3.IntegrityError:
+            raise ProcessingError(f"Node '{node_id}' already exists.")
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        cur = self.conn.execute("SELECT attributes FROM nodes WHERE id=?", (node_id,))
+        row = cur.fetchone()
+        if row is None:
+            raise ProcessingError(f"Node '{node_id}' not found for update.")
+        data = json.loads(row["attributes"])
+        data.update(attributes)
+        with self.conn:
+            self.conn.execute(
+                "UPDATE nodes SET attributes=? WHERE id=?",
+                (json.dumps(data), node_id),
+            )
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        cur = self.conn.execute("SELECT attributes FROM nodes WHERE id=?", (node_id,))
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return json.loads(row["attributes"])
+
+    def node_exists(self, node_id: str) -> bool:
+        cur = self.conn.execute("SELECT 1 FROM nodes WHERE id=?", (node_id,))
+        return cur.fetchone() is not None
+
+    def get_all_node_ids(self) -> List[str]:
+        cur = self.conn.execute("SELECT id FROM nodes")
+        return [row["id"] for row in cur.fetchall()]
+
+    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
+            raise ProcessingError(
+                f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
+            )
+        try:
+            with self.conn:
+                self.conn.execute(
+                    "INSERT INTO edges(source, target, label) VALUES(?, ?, ?)",
+                    (source_node_id, target_node_id, label),
+                )
+        except sqlite3.IntegrityError:
+            raise ProcessingError(
+                f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
+            )
+
+    def get_all_edges(self) -> List[Tuple[str, str, str]]:
+        cur = self.conn.execute("SELECT source, target, label FROM edges")
+        return [(row["source"], row["target"], row["label"]) for row in cur.fetchall()]
+
+    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self.conn:
+            cur = self.conn.execute(
+                "DELETE FROM edges WHERE source=? AND target=? AND label=?",
+                (source_node_id, target_node_id, label),
+            )
+            if cur.rowcount == 0:
+                edge_tuple = (source_node_id, target_node_id, label)
+                raise ProcessingError(
+                    f"Edge {edge_tuple} does not exist and cannot be deleted."
+                )
+
+    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> List[str]:
+        if not self.node_exists(node_id):
+            raise ProcessingError(f"Node '{node_id}' not found.")
+        if edge_label:
+            cur = self.conn.execute(
+                "SELECT target FROM edges WHERE source=? AND label=?",
+                (node_id, edge_label),
+            )
+        else:
+            cur = self.conn.execute("SELECT target FROM edges WHERE source=?", (node_id,))
+        return [row["target"] for row in cur.fetchall()]
+
+    def clear(self) -> None:
+        with self.conn:
+            self.conn.execute("DELETE FROM edges")
+            self.conn.execute("DELETE FROM nodes")
+
+    @property
+    def node_count(self) -> int:
+        cur = self.conn.execute("SELECT COUNT(*) AS cnt FROM nodes")
+        row = cur.fetchone()
+        return int(row["cnt"]) if row else 0
+
+    def dump(self) -> Dict[str, Any]:
+        nodes: Dict[str, Any] = {}
+        for row in self.conn.execute("SELECT id, attributes FROM nodes"):
+            nodes[row["id"]] = json.loads(row["attributes"])
+        edges = self.get_all_edges()
+        return {"nodes": nodes, "edges": edges}

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -3,8 +3,8 @@ import json
 from typing import Union, List, Tuple
 import pathlib  # For type hinting path-like objects
 
-# Ensure MockGraph is available for instantiation and type hinting
-from .graph import MockGraph
+from .persistent_graph import PersistentGraph
+from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 
 
@@ -12,16 +12,16 @@ class SnapshotError(ValueError):
     """Custom exception for snapshot loading or validation errors."""
     pass
 
-def snapshot_graph_to_file(graph: MockGraph, path: Union[str, pathlib.Path]) -> None:
+def snapshot_graph_to_file(graph: IGraphAdapter, path: Union[str, pathlib.Path]) -> None:
     """
-    Snapshots the given MockGraph's current state to a JSON file.
+    Snapshots the given graph's current state to a JSON file.
 
     The snapshot includes the data returned by ``graph.dump()``, which
     contains both nodes and edges. The JSON file is pretty-printed with an
     indent of 2 spaces.
 
     Args:
-        graph: The MockGraph instance to snapshot.
+        graph: The graph instance to snapshot.
         path: The file path (string or pathlib.Path object) where the
               JSON snapshot will be saved.
 
@@ -33,9 +33,9 @@ def snapshot_graph_to_file(graph: MockGraph, path: Union[str, pathlib.Path]) -> 
     with open(path, "w", encoding='utf-8') as f:
         json.dump(dumped_data, f, indent=2)
 
-def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
+def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
     """
-    Loads a graph state from a JSON snapshot file into a new MockGraph instance.
+    Loads a graph state from a JSON snapshot file into a new PersistentGraph instance.
 
     The JSON file is expected to contain data previously saved by
     `snapshot_graph_to_file`. It should have a top-level "nodes" key mapping
@@ -48,7 +48,7 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
               the JSON snapshot.
 
     Returns:
-        MockGraph: A new MockGraph instance populated with data from the snapshot file.
+        PersistentGraph: A new PersistentGraph instance populated with data from the snapshot file.
 
     Raises:
         FileNotFoundError: If the specified path does not exist.
@@ -75,15 +75,14 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
     if not isinstance(data["nodes"], dict):
         raise SnapshotError(f"Invalid snapshot format: 'nodes' should be a dictionary, got {type(data['nodes']).__name__}.")
 
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     for node_id, attributes in data["nodes"].items():
         if not isinstance(attributes, dict):
             raise SnapshotError(
                 f"Invalid snapshot format for node '{node_id}': attributes should be a dictionary, "
                 f"got {type(attributes).__name__}."
             )
-        # Since MockGraph.add_node expects attributes to be Dict[str, Any],
-        # and json.load ensures keys are strings, this should be fine.
+        # json.load ensures keys are strings, so this matches the adapter API.
         graph.add_node(node_id, attributes.copy()) # Use .copy() for attributes
 
     # Load edges if present
@@ -122,3 +121,14 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
                 ) from e
 
     return graph
+
+
+def load_graph_into_existing(graph: IGraphAdapter, path: Union[str, pathlib.Path]) -> None:
+    """Load snapshot data from ``path`` into an existing graph adapter."""
+    loaded = load_graph_from_file(path)
+    graph.clear()
+    for node_id in loaded.get_all_node_ids():
+        attrs = loaded.get_node(node_id) or {}
+        graph.add_node(node_id, attrs)
+    for src, tgt, lbl in loaded.get_all_edges():
+        graph.add_edge(src, tgt, lbl)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -24,13 +24,16 @@ def run_cli_commands(commands: list[str], timeout: int = 5) -> tuple[str, str, i
         A tuple (stdout, stderr, returncode) from the CLI process. If the CLI
         exits with a non-zero status, the test fails.
     """
+    env = os.environ.copy()
+    env["UME_CLI_DB"] = ":memory:"
     process = subprocess.Popen(
         [sys.executable, CLI_SCRIPT_PATH],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        encoding='utf-8' # Be explicit about encoding
+        encoding='utf-8', # Be explicit about encoding
+        env=env,
     )
     # Join commands with newlines and ensure a final newline for the last command
     # and to trigger EOF for cmdloop if 'exit' is not the last command.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,21 +1,21 @@
 # tests/test_graph.py
 import pytest
 import re
-from ume import MockGraph, ProcessingError  # IGraphAdapter is implicitly tested by testing MockGraph's adherence
+from ume import PersistentGraph, ProcessingError
 from ume.graph_adapter import IGraphAdapter  # Import for isinstance check if needed
 
-# Fixture for a clean MockGraph instance
+# Fixture for a clean PersistentGraph instance
 @pytest.fixture
-def graph() -> MockGraph:
-    """Provides a clean MockGraph instance for each test."""
-    return MockGraph()
+def graph() -> PersistentGraph:
+    """Provides a clean PersistentGraph (in-memory) instance for each test."""
+    return PersistentGraph(":memory:")
 
-def test_mockgraph_is_igraph_adapter_instance(graph: MockGraph):
-    """Test that MockGraph is an instance of IGraphAdapter."""
+def test_graph_is_igraph_adapter_instance(graph: PersistentGraph):
+    """Test that PersistentGraph is an instance of IGraphAdapter."""
     assert isinstance(graph, IGraphAdapter)
 
 # --- add_node tests ---
-def test_add_node_success(graph: MockGraph):
+def test_add_node_success(graph: PersistentGraph):
     """Test adding a new node successfully."""
     node_id = "node1"
     attributes = {"name": "Test Node", "value": 123}
@@ -24,7 +24,7 @@ def test_add_node_success(graph: MockGraph):
     assert graph.get_node(node_id) == attributes
     assert graph.node_count == 1
 
-def test_add_node_empty_attributes_success(graph: MockGraph):
+def test_add_node_empty_attributes_success(graph: PersistentGraph):
     """Test adding a new node with empty attributes successfully."""
     node_id = "node_empty_attr"
     attributes = {}
@@ -32,7 +32,7 @@ def test_add_node_empty_attributes_success(graph: MockGraph):
     assert graph.node_exists(node_id)
     assert graph.get_node(node_id) == {}
 
-def test_add_node_duplicate_raises_error(graph: MockGraph):
+def test_add_node_duplicate_raises_error(graph: PersistentGraph):
     """Test that adding a node with an existing ID raises ProcessingError."""
     node_id = "node1"
     attributes1 = {"name": "First Node"}
@@ -42,7 +42,7 @@ def test_add_node_duplicate_raises_error(graph: MockGraph):
         graph.add_node(node_id, attributes2) # Attempt duplicate add
 
 # --- update_node tests ---
-def test_update_node_success(graph: MockGraph):
+def test_update_node_success(graph: PersistentGraph):
     """Test updating an existing node's attributes successfully."""
     node_id = "node1"
     initial_attributes = {"name": "Initial Name", "version": 1}
@@ -54,7 +54,7 @@ def test_update_node_success(graph: MockGraph):
 
     assert graph.get_node(node_id) == expected_attributes
 
-def test_update_node_with_empty_attributes_dict(graph: MockGraph):
+def test_update_node_with_empty_attributes_dict(graph: PersistentGraph):
     """Test updating with an empty attributes dictionary (should result in no change)."""
     node_id = "node1"
     initial_attributes = {"name": "Initial Name"}
@@ -64,7 +64,7 @@ def test_update_node_with_empty_attributes_dict(graph: MockGraph):
 
     assert graph.get_node(node_id) == initial_attributes # Attributes should remain unchanged
 
-def test_update_node_non_existent_raises_error(graph: MockGraph):
+def test_update_node_non_existent_raises_error(graph: PersistentGraph):
     """Test that updating a non-existent node raises ProcessingError."""
     node_id = "node_not_found"
     attributes = {"name": "Attempted Update"}
@@ -72,30 +72,30 @@ def test_update_node_non_existent_raises_error(graph: MockGraph):
         graph.update_node(node_id, attributes)
 
 # --- get_node tests ---
-def test_get_node_exists(graph: MockGraph):
+def test_get_node_exists(graph: PersistentGraph):
     """Test get_node for an existing node."""
     node_id = "node1"
     attributes = {"data": "some_data"}
     graph.add_node(node_id, attributes)
     assert graph.get_node(node_id) == attributes
 
-def test_get_node_not_exists(graph: MockGraph):
+def test_get_node_not_exists(graph: PersistentGraph):
     """Test get_node for a non-existent node."""
     assert graph.get_node("node_not_found") is None
 
 # --- node_exists tests ---
-def test_node_exists_true(graph: MockGraph):
+def test_node_exists_true(graph: PersistentGraph):
     """Test node_exists for an existing node."""
     node_id = "node1"
     graph.add_node(node_id, {})
     assert graph.node_exists(node_id) is True
 
-def test_node_exists_false(graph: MockGraph):
+def test_node_exists_false(graph: PersistentGraph):
     """Test node_exists for a non-existent node."""
     assert graph.node_exists("node_not_found") is False
 
 # --- clear tests ---
-def test_clear_graph_with_nodes_and_edges(graph: MockGraph): # Renamed for clarity
+def test_clear_graph_with_nodes_and_edges(graph: PersistentGraph): # Renamed for clarity
     """Test clearing the graph with both nodes and edges."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -112,7 +112,7 @@ def test_clear_graph_with_nodes_and_edges(graph: MockGraph): # Renamed for clari
     assert graph.dump() == {"nodes": {}, "edges": []} # Check dump output
 
 # --- dump tests (basic check, detailed serialization in test_graph_serialization.py) ---
-def test_dump_structure(graph: MockGraph):
+def test_dump_structure(graph: PersistentGraph):
     """Test the basic structure of the dump method output."""
     node_id = "node1"
     attributes = {"key": "value"}
@@ -122,18 +122,18 @@ def test_dump_structure(graph: MockGraph):
     assert node_id in dump_data["nodes"]
     assert dump_data["nodes"][node_id] == attributes
 
-def test_dump_empty_graph_structure(graph: MockGraph):
+def test_dump_empty_graph_structure(graph: PersistentGraph):
     """Test dump structure for an empty graph."""
     dump_data = graph.dump()
     assert "nodes" in dump_data
     assert dump_data["nodes"] == {}
 
 # --- get_all_node_ids tests ---
-def test_get_all_node_ids_empty_graph(graph: MockGraph):
+def test_get_all_node_ids_empty_graph(graph: PersistentGraph):
     """Test get_all_node_ids on an empty graph."""
     assert graph.get_all_node_ids() == []
 
-def test_get_all_node_ids_populated_graph(graph: MockGraph):
+def test_get_all_node_ids_populated_graph(graph: PersistentGraph):
     """Test get_all_node_ids on a graph with multiple nodes."""
     graph.add_node("node1", {})
     graph.add_node("node2", {"data": "value"})
@@ -146,7 +146,7 @@ def test_get_all_node_ids_populated_graph(graph: MockGraph):
     assert set(node_ids) == {"node1", "node2", "alpha"}
 
 # --- add_edge tests (New) ---
-def test_add_edge_success(graph: MockGraph):
+def test_add_edge_success(graph: PersistentGraph):
     """Test adding a valid edge successfully."""
     graph.add_node("nodeS", {})
     graph.add_node("nodeT", {})
@@ -156,35 +156,35 @@ def test_add_edge_success(graph: MockGraph):
     assert len(all_edges) == 1
     assert ("nodeS", "nodeT", "RELATES_TO") in all_edges
 
-def test_add_edge_missing_source_node_raises_error(graph: MockGraph):
+def test_add_edge_missing_source_node_raises_error(graph: PersistentGraph):
     """Test ProcessingError when adding an edge with a non-existent source node."""
     graph.add_node("nodeT", {}) # Target node exists
     with pytest.raises(ProcessingError, match="Both source node 'nodeS_missing' and target node 'nodeT' must exist"):
         graph.add_edge("nodeS_missing", "nodeT", "LINKS_TO")
 
-def test_add_edge_missing_target_node_raises_error(graph: MockGraph):
+def test_add_edge_missing_target_node_raises_error(graph: PersistentGraph):
     """Test ProcessingError when adding an edge with a non-existent target node."""
     graph.add_node("nodeS", {}) # Source node exists
     with pytest.raises(ProcessingError, match="Both source node 'nodeS' and target node 'nodeT_missing' must exist"):
         graph.add_edge("nodeS", "nodeT_missing", "CONNECTS_TO")
 
-def test_add_edge_both_nodes_missing_raises_error(graph: MockGraph):
+def test_add_edge_both_nodes_missing_raises_error(graph: PersistentGraph):
     """Test ProcessingError when adding an edge with both source and target nodes non-existent."""
     with pytest.raises(ProcessingError, match="Both source node 'nodeS_missing' and target node 'nodeT_missing' must exist"):
         graph.add_edge("nodeS_missing", "nodeT_missing", "IS_RELATED_TO")
 
 # --- get_all_edges tests (New) ---
-def test_get_all_edges_empty_graph(graph: MockGraph):
+def test_get_all_edges_empty_graph(graph: PersistentGraph):
     """Test get_all_edges on a graph with no edges (and no nodes)."""
     assert graph.get_all_edges() == []
 
-def test_get_all_edges_no_edges_but_nodes_exist(graph: MockGraph):
+def test_get_all_edges_no_edges_but_nodes_exist(graph: PersistentGraph):
     """Test get_all_edges on a graph with nodes but no edges."""
     graph.add_node("node1", {})
     graph.add_node("node2", {})
     assert graph.get_all_edges() == []
 
-def test_get_all_edges_populated(graph: MockGraph):
+def test_get_all_edges_populated(graph: PersistentGraph):
     """Test get_all_edges on a graph with multiple edges."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -207,7 +207,7 @@ def test_get_all_edges_populated(graph: MockGraph):
 # --- find_connected_nodes tests ---
 # Old test_find_connected_nodes_existing_node_returns_empty_list removed as behavior changed.
 
-def test_find_connected_nodes_non_existent_node_raises_error(graph: MockGraph):
+def test_find_connected_nodes_non_existent_node_raises_error(graph: PersistentGraph):
     """
     Test find_connected_nodes for a non-existent node.
     Should raise ProcessingError.
@@ -218,7 +218,7 @@ def test_find_connected_nodes_non_existent_node_raises_error(graph: MockGraph):
     with pytest.raises(ProcessingError, match="Node 'another_missing' not found."):
         graph.find_connected_nodes("another_missing", edge_label="ANY_LABEL")
 
-def test_find_connected_nodes_with_edges(graph: MockGraph):
+def test_find_connected_nodes_with_edges(graph: PersistentGraph):
     """Test find_connected_nodes when edges exist."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -241,7 +241,7 @@ def test_find_connected_nodes_with_edges(graph: MockGraph):
     connected_different_rel = graph.find_connected_nodes("n1", edge_label="DIFFERENT_REL")
     assert set(connected_different_rel) == {"n4"}
 
-def test_find_connected_nodes_no_matching_edges(graph: MockGraph):
+def test_find_connected_nodes_no_matching_edges(graph: PersistentGraph):
     """Test find_connected_nodes when no outgoing edges match."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -254,7 +254,7 @@ def test_find_connected_nodes_no_matching_edges(graph: MockGraph):
     assert graph.find_connected_nodes("n3") == []
 
 # --- delete_edge tests (New) ---
-def test_delete_edge_success(graph: MockGraph):
+def test_delete_edge_success(graph: PersistentGraph):
     """Test deleting an existing edge successfully."""
     graph.add_node("s1", {})
     graph.add_node("t1", {})
@@ -268,7 +268,7 @@ def test_delete_edge_success(graph: MockGraph):
     assert edge_to_delete not in graph.get_all_edges()
     assert len(graph.get_all_edges()) == 0
 
-def test_delete_multiple_edges(graph: MockGraph):
+def test_delete_multiple_edges(graph: PersistentGraph):
     """Test deleting one edge when multiple exist."""
     graph.add_node("s", {})
     graph.add_node("t1", {})
@@ -289,7 +289,7 @@ def test_delete_multiple_edges(graph: MockGraph):
     assert edge2 in graph.get_all_edges() # Edge2 should still be there
     assert len(graph.get_all_edges()) == 1
 
-def test_delete_edge_non_existent_raises_error(graph: MockGraph):
+def test_delete_edge_non_existent_raises_error(graph: PersistentGraph):
     """Test that attempting to delete a non-existent edge raises ProcessingError."""
     graph.add_node("s1", {})
     graph.add_node("t1", {})
@@ -300,10 +300,10 @@ def test_delete_edge_non_existent_raises_error(graph: MockGraph):
     with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
 
-def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph):
+def test_delete_edge_non_existent_source_node_implicitly_fails(graph: PersistentGraph):
     """
     Test deleting an edge where source node doesn't exist.
-    (MockGraph.delete_edge currently doesn't check node existence, only edge tuple).
+    (PersistentGraph.delete_edge currently doesn't check node existence, only edge tuple).
     This test confirms it fails because the edge tuple wouldn't be found.
     """
     graph.add_node("t1", {})
@@ -312,7 +312,7 @@ def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph)
     with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
 
-def test_delete_edge_non_existent_target_node_implicitly_fails(graph: MockGraph):
+def test_delete_edge_non_existent_target_node_implicitly_fails(graph: PersistentGraph):
     """
     Test deleting an edge where target node doesn't exist.
     (Similar to above, fails due to edge tuple not found).

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -3,11 +3,11 @@ import json
 import pytest
 import pathlib  # Ensure pathlib is imported
 import re
-from ume import MockGraph, snapshot_graph_to_file, load_graph_from_file, SnapshotError  # Add new imports
+from ume import PersistentGraph, snapshot_graph_to_file, load_graph_from_file, SnapshotError  # Add new imports
 
 def test_empty_graph_dump_and_serialization():
     """Test dumping an empty graph and serializing it."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     dumped_data = graph.dump()
 
     assert "nodes" in dumped_data
@@ -26,7 +26,7 @@ def test_empty_graph_dump_and_serialization():
 
 def test_graph_serialization_roundtrip_with_nodes_and_edges():
     """Test dumping a graph with nodes and edges, serializing, and deserializing."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     node_a_attrs = {"name": "Alice", "type": "person"}
     node_b_attrs = {"name": "Bob", "value": 42}
 
@@ -77,7 +77,7 @@ def test_graph_serialization_roundtrip_with_nodes_and_edges():
 
 def test_dump_returns_copy_not_reference():
     """Test that graph.dump()['nodes'] is a copy, not a reference to internal _nodes."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     node_attrs = {"feature": "original"}
     graph.add_node("node1", node_attrs)
 
@@ -92,13 +92,12 @@ def test_dump_returns_copy_not_reference():
     assert original_node_attrs is not None
     assert original_node_attrs["feature"] == "original"
     assert graph.node_exists("new_node_in_dump") is False
-    assert len(graph._nodes) == 1 # Accessing protected member for test validation
 
 # New tests for snapshot_graph_to_file
 
 def test_snapshot_empty_graph_roundtrip(tmp_path: pathlib.Path):
     """Test snapshotting an empty graph and restoring it from file."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     snapshot_file_path = tmp_path / "empty_snapshot.json"
 
     # Create snapshot
@@ -116,7 +115,7 @@ def test_snapshot_empty_graph_roundtrip(tmp_path: pathlib.Path):
 
 def test_snapshot_graph_with_nodes_roundtrip(tmp_path: pathlib.Path):
     """Test snapshotting a graph with nodes and restoring it from file."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     node_a_attrs = {"name": "Alice", "age": 30, "tags": ["dev", "python"]}
     node_b_attrs = {"name": "Bob", "department": "HR", "active": True}
     node_c_attrs = {} # Node with empty attributes
@@ -150,7 +149,7 @@ def test_snapshot_graph_with_nodes_roundtrip(tmp_path: pathlib.Path):
 
 def test_snapshot_file_content_is_pretty_printed(tmp_path: pathlib.Path):
     """Verify that the snapshot JSON file is pretty-printed."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     graph.add_node("node1", {"name": "Test", "data": [1, 2]})
     snapshot_file_path = tmp_path / "pretty_print_test.json"
 
@@ -170,19 +169,19 @@ def test_snapshot_file_content_is_pretty_printed(tmp_path: pathlib.Path):
 
 def test_load_graph_from_file_success_empty_graph(tmp_path: pathlib.Path):
     """Test loading an empty graph from a valid snapshot file."""
-    graph = MockGraph()
+    graph = PersistentGraph(":memory:")
     snapshot_file = tmp_path / "empty_graph_to_load.json"
     snapshot_graph_to_file(graph, snapshot_file)
 
     loaded_graph = load_graph_from_file(snapshot_file)
-    assert isinstance(loaded_graph, MockGraph)
+    assert isinstance(loaded_graph, PersistentGraph)
     assert loaded_graph.node_count == 0
     assert loaded_graph.dump()["nodes"] == {}
     assert loaded_graph.get_all_edges() == [] # New assertion
 
 def test_load_graph_from_file_success_populated_graph(tmp_path: pathlib.Path):
     """Test loading a populated graph from a valid snapshot file."""
-    original_graph = MockGraph()
+    original_graph = PersistentGraph(":memory:")
     attrs1 = {"name": "Node 1", "value": 10}
     attrs2 = {"name": "Node 2", "active": True}
     original_graph.add_node("n1", attrs1)
@@ -194,7 +193,7 @@ def test_load_graph_from_file_success_populated_graph(tmp_path: pathlib.Path):
     snapshot_graph_to_file(original_graph, snapshot_file)
 
     loaded_graph = load_graph_from_file(snapshot_file)
-    assert isinstance(loaded_graph, MockGraph)
+    assert isinstance(loaded_graph, PersistentGraph)
     assert loaded_graph.node_count == 2
     assert loaded_graph.get_node("n1") == attrs1
     assert loaded_graph.get_node("n2") == attrs2


### PR DESCRIPTION
## Summary
- create `PersistentGraph` backed by SQLite
- add periodic snapshot utility
- use persistent graph in CLI with env-configured DB path
- support loading snapshots into arbitrary graph
- update docs for persistent graph and immutable event log
- migrate tests to use persistent graph

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d85e187c8326bbce0e3b6b452aa5