### PR TITLE
Implement event schemas and validation

### DIFF
--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -1,12 +1,46 @@
-# UME Graph Model (Planned)
+# UME Graph Model
 
-The Universal Memory Engine (UME) is designed to build and utilize a knowledge graph based on ingested events. This document will detail the schema and structure of that graph, including:
+This document defines the initial ontology used by the Universal Memory Engine.
+It describes node types, edge labels and general versioning guidelines for the
+graph representation.
 
-*   **Node Types:** The different kinds of entities that will be represented as nodes in the graph (e.g., users, sessions, concepts, external data points).
-*   **Relationship Types:** The types of connections or edges that can exist between nodes (e.g., `HAS_SESSION`, `MENTIONED_CONCEPT`, `RELATED_TO`).
-*   **Properties:** The attributes associated with nodes and relationships.
-*   **Labels:** How nodes and relationships are categorized or labeled for efficient querying and reasoning.
+## Node Types
 
-This section is currently a placeholder. As the UME system's graph processing capabilities are implemented and refined, this document will be updated with the concrete details of the graph model.
+### UserMemory
+Represents memory items about a specific user.
 
-The goal is to create a flexible yet structured graph that can provide rich, context-aware memory for AI agents and automations.
+Properties:
+- `user_id` *(string, required)*: unique identifier of the user.
+- `data` *(object)*: free form attributes describing the memory.
+
+### AgentIntent
+Captures an intention produced by an agent.
+
+Properties:
+- `intent_id` *(string, required)*: unique identifier for the intent.
+- `description` *(string)*: short human friendly description.
+
+### PerceptualContext
+Stores sensory observations that provide context for reasoning.
+
+Properties:
+- `context_id` *(string, required)*: unique identifier.
+- `modality` *(string)*: e.g. `vision`, `audio`.
+- `payload` *(object)*: raw or processed perceptual data.
+
+## Edge Labels
+
+- `REMEMBERS`: connects a `UserMemory` node to an `AgentIntent` that created it.
+- `ASSOCIATED_WITH`: generic association between any two nodes.
+- `CAUSES`: expresses a causal relationship from one event or context to another.
+
+Each edge is directed and labeled and may carry optional properties in the
+future.  At minimum an edge stores the source node ID, target node ID and
+its label.
+
+## Versioning
+
+The schema is expected to evolve.  Node and edge type definitions should be
+additive where possible.  Breaking changes to existing types require a new major
+schema version.  Each schema file will include a `version` field so producers and
+consumers can negotiate compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.12"
 confluent-kafka = ">=2.4"
 fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.
+jsonschema = ">=4.17"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "*"

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -6,6 +6,7 @@ from .graph import MockGraph
 from .graph_adapter import IGraphAdapter
 from .processing import apply_event_to_graph, ProcessingError
 from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError
+from .schema_utils import validate_event_dict
 
 __all__ = [
     "Event", "EventType", "parse_event", "EventError",
@@ -14,5 +15,6 @@ __all__ = [
     "apply_event_to_graph", "ProcessingError",
     "snapshot_graph_to_file",
     "load_graph_from_file",
-    "SnapshotError"
+    "SnapshotError",
+    "validate_event_dict",
 ]

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -9,7 +9,9 @@ import json
 import logging
 import time
 from confluent_kafka import Producer, KafkaException  # type: ignore
-from ume import Event # Import Event
+from jsonschema import ValidationError  # type: ignore
+from ume import Event
+from ume.schema_utils import validate_event_dict
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -57,6 +59,13 @@ def main():
         "payload": event_to_send.payload,
         "source": event_to_send.source
     }
+
+    try:
+        validate_event_dict(data_dict)
+    except ValidationError as e:
+        logger.error("Event failed schema validation: %s", e)
+        return
+
     data = json.dumps(data_dict).encode("utf-8")
 
     logger.info(f"Producing event object to topic '{TOPIC}': {event_to_send}")

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -1,0 +1,30 @@
+"""Utilities for validating UME events against JSON Schemas."""
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any, Dict
+
+from jsonschema import validate, ValidationError  # type: ignore
+
+
+_SCHEMAS: Dict[str, Dict[str, Any]] = {}
+
+
+def _load_schema(event_type: str) -> Dict[str, Any]:
+    """Load JSON schema for a specific event type."""
+    if event_type not in _SCHEMAS:
+        filename = f"{event_type.lower()}.schema.json"
+        with resources.files("ume.schemas").joinpath(filename).open("r", encoding="utf-8") as f:
+            _SCHEMAS[event_type] = json.load(f)
+    return _SCHEMAS[event_type]
+
+
+def validate_event_dict(event_data: Dict[str, Any]) -> None:
+    """Validate a raw event dictionary against its JSON schema."""
+    event_type = event_data.get("event_type")
+    if not isinstance(event_type, str):
+        raise ValidationError("event_type missing or not a string")
+    schema = _load_schema(event_type)
+    validate(instance=event_data, schema=schema)
+

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_EDGE event",
+  "type": "object",
+  "required": ["event_type", "timestamp", "node_id", "target_node_id", "label"],
+  "properties": {
+    "event_type": {"const": "CREATE_EDGE"},
+    "timestamp": {"type": "integer"},
+    "event_id": {"type": "string"},
+    "source": {"type": "string"},
+    "node_id": {"type": "string"},
+    "target_node_id": {"type": "string"},
+    "label": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_NODE event",
+  "type": "object",
+  "required": ["event_type", "timestamp", "node_id", "payload"],
+  "properties": {
+    "event_type": {"const": "CREATE_NODE"},
+    "timestamp": {"type": "integer"},
+    "event_id": {"type": "string"},
+    "source": {"type": "string"},
+    "node_id": {"type": "string"},
+    "payload": {"type": "object"},
+    "target_node_id": {"type": "string"},
+    "label": {"type": "string"}
+  }
+}

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DELETE_EDGE event",
+  "type": "object",
+  "required": ["event_type", "timestamp", "node_id", "target_node_id", "label"],
+  "properties": {
+    "event_type": {"const": "DELETE_EDGE"},
+    "timestamp": {"type": "integer"},
+    "event_id": {"type": "string"},
+    "source": {"type": "string"},
+    "node_id": {"type": "string"},
+    "target_node_id": {"type": "string"},
+    "label": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UPDATE_NODE_ATTRIBUTES event",
+  "type": "object",
+  "required": ["event_type", "timestamp", "node_id", "payload"],
+  "properties": {
+    "event_type": {"const": "UPDATE_NODE_ATTRIBUTES"},
+    "timestamp": {"type": "integer"},
+    "event_id": {"type": "string"},
+    "source": {"type": "string"},
+    "node_id": {"type": "string"},
+    "payload": {"type": "object"},
+    "target_node_id": {"type": "string"},
+    "label": {"type": "string"}
+  }
+}


### PR DESCRIPTION
## Summary
- define JSON schemas for all event types
- add schema validation utilities
- validate producer_demo events against schemas
- document node and edge ontology in GRAPH_MODEL.md
- expose validation helper via package exports
- require jsonschema dependency

## Testing
- `pre-commit run --files src/ume/producer_demo.py src/ume/schema_utils.py src/ume/__init__.py docs/GRAPH_MODEL.md pyproject.toml src/ume/schemas/create_node.schema.json src/ume/schemas/update_node_attributes.schema.json src/ume/schemas/create_edge.schema.json src/ume/schemas/delete_edge.schema.json`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d86bc9088326982320a2ae73b159