### PR TITLE
Implement RBAC wrapper and ACL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ When contributing new features or fixing bugs, please include relevant tests:
 
 Strive for clear, concise tests that verify specific behaviors and edge cases.
 
+## Access Control
+
+UME enforces access restrictions for both Kafka topics and graph operations.
+Example ACL commands for Redpanda and a description of roles are provided in
+[docs/ACCESS_CONTROL.md](docs/ACCESS_CONTROL.md).
+
 ## Quickstart
 
 ### Prerequisites

--- a/docker/setup-redpanda-acls.sh
+++ b/docker/setup-redpanda-acls.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Example ACL configuration for Redpanda using rpk.
+# Run inside the docker compose environment where rpk is available.
+set -e
+
+# Create service accounts
+rpk acl user create autodev || true
+rpk acl user create culture_ai || true
+rpk acl user create ume_service || true
+
+# AutoDev permissions
+rpk acl create --allow-principal User:autodev --operation produce --topic autodev-events
+rpk acl create --allow-principal User:autodev --operation consume --topic autodev-events --group autodev-group
+
+# Culture.ai permissions
+rpk acl create --allow-principal User:culture_ai --operation produce --topic culture-events
+rpk acl create --allow-principal User:culture_ai --operation consume --topic culture-events --group culture-group
+
+# UME service permissions
+rpk acl create --allow-principal User:ume_service --operation produce --topic ume-events
+rpk acl create --allow-principal User:ume_service --operation consume --topic ume-events --group ume-group

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -1,0 +1,27 @@
+# Access Control
+
+This document describes how access control is applied across UME components.
+
+## Redpanda ACLs
+
+Each sub-agent operates with its own service principal. Example accounts:
+
+- `autodev`
+- `culture_ai`
+- `ume_service`
+
+Use `rpk` to create accounts and restrict topic access. The script
+`docker/setup-redpanda-acls.sh` contains example commands. Each agent is
+limited to producing and consuming only its designated topics.
+
+## Graph Role Based Access
+
+The graph adapter includes a role based wrapper. Two roles are currently
+enforced:
+
+- **UserService** – allowed to create or update nodes whose IDs begin with
+  `UserProfile.`.
+- **AnalyticsAgent** – allowed to run advanced queries such as
+  `find_connected_nodes`.
+
+Other roles attempting these operations will receive an `AccessDeniedError`.

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -4,6 +4,7 @@ Universal Memory Engine (UME) core package.
 from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
 from .graph_adapter import IGraphAdapter
+from .rbac_adapter import RoleBasedGraphAdapter, AccessDeniedError
 from .processing import apply_event_to_graph, ProcessingError
 from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError
 
@@ -11,6 +12,8 @@ __all__ = [
     "Event", "EventType", "parse_event", "EventError",
     "MockGraph",
     "IGraphAdapter",
+    "RoleBasedGraphAdapter",
+    "AccessDeniedError",
     "apply_event_to_graph", "ProcessingError",
     "snapshot_graph_to_file",
     "load_graph_from_file",

--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -1,0 +1,66 @@
+"""Role-based wrapper around IGraphAdapter."""
+from typing import Dict, Any, Optional
+
+from .graph_adapter import IGraphAdapter
+
+
+class AccessDeniedError(PermissionError):
+    """Raised when a graph operation is not permitted for the current role."""
+
+
+class RoleBasedGraphAdapter(IGraphAdapter):
+    """Wraps another adapter and enforces basic role-based access control."""
+
+    def __init__(self, adapter: IGraphAdapter, role: str):
+        self._adapter = adapter
+        self.role = role
+
+    # Internal helpers -----------------------------------------------------
+    def _check_user_profile_access(self, node_id: str) -> None:
+        if node_id.startswith("UserProfile.") and self.role != "UserService":
+            raise AccessDeniedError(
+                "Only the 'UserService' role may modify UserProfile nodes"
+            )
+
+    def _require_analytics_role(self) -> None:
+        if self.role != "AnalyticsAgent":
+            raise AccessDeniedError(
+                "Only the 'AnalyticsAgent' role may perform this operation"
+            )
+
+    # IGraphAdapter methods ------------------------------------------------
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        self._check_user_profile_access(node_id)
+        self._adapter.add_node(node_id, attributes)
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        self._check_user_profile_access(node_id)
+        self._adapter.update_node(node_id, attributes)
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        return self._adapter.get_node(node_id)
+
+    def node_exists(self, node_id: str) -> bool:
+        return self._adapter.node_exists(node_id)
+
+    def dump(self) -> Dict[str, Any]:
+        return self._adapter.dump()
+
+    def clear(self) -> None:
+        self._adapter.clear()
+
+    def get_all_node_ids(self) -> list[str]:
+        return self._adapter.get_all_node_ids()
+
+    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> list[str]:
+        self._require_analytics_role()
+        return self._adapter.find_connected_nodes(node_id, edge_label)
+
+    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        self._adapter.add_edge(source_node_id, target_node_id, label)
+
+    def get_all_edges(self) -> list[tuple[str, str, str]]:
+        return self._adapter.get_all_edges()
+
+    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        self._adapter.delete_edge(source_node_id, target_node_id, label)

--- a/tests/test_rbac_adapter.py
+++ b/tests/test_rbac_adapter.py
@@ -1,0 +1,25 @@
+import pytest
+from ume import MockGraph, RoleBasedGraphAdapter, AccessDeniedError
+
+
+def test_user_profile_edit_requires_user_service():
+    graph = MockGraph()
+    rbac = RoleBasedGraphAdapter(graph, role="AutoDev")
+    with pytest.raises(AccessDeniedError):
+        rbac.add_node("UserProfile.1", {})
+
+    rbac_allowed = RoleBasedGraphAdapter(graph, role="UserService")
+    rbac_allowed.add_node("UserProfile.1", {})
+    assert graph.node_exists("UserProfile.1")
+
+
+def test_find_connected_nodes_requires_analytics_agent():
+    graph = MockGraph()
+    graph.add_node("n1", {})
+    rbac = RoleBasedGraphAdapter(graph, role="AutoDev")
+    with pytest.raises(AccessDeniedError):
+        rbac.find_connected_nodes("n1")
+
+    analytics = RoleBasedGraphAdapter(graph, role="AnalyticsAgent")
+    assert analytics.find_connected_nodes("n1") == []
+


### PR DESCRIPTION
## Summary
- document Kafka and graph roles in ACCESS_CONTROL.md
- add example Redpanda ACL setup script
- implement `RoleBasedGraphAdapter` with `AccessDeniedError`
- export new adapter in `ume` package
- add tests for RBAC behavior
- note access control documentation in README

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d895ba3c8326adc40693ff719f2d