### PR TITLE
Add query engine analytics and API

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,16 @@ python = "^3.12"
 confluent-kafka = ">=2.4"
 fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.
+neo4j = "*"
+networkx = "*"
+fastapi = "*"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "*"
 mypy = "*"
 pytest = "*"
 pytest-cov = "*"
+httpx = "*"
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -4,6 +4,9 @@ Universal Memory Engine (UME) core package.
 from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
 from .graph_adapter import IGraphAdapter
+from .query import Neo4jQueryEngine
+from .analytics import shortest_path, find_communities, temporal_node_counts
+from .api import app as api_app
 from .processing import apply_event_to_graph, ProcessingError
 from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError
 
@@ -11,6 +14,11 @@ __all__ = [
     "Event", "EventType", "parse_event", "EventError",
     "MockGraph",
     "IGraphAdapter",
+    "Neo4jQueryEngine",
+    "shortest_path",
+    "find_communities",
+    "temporal_node_counts",
+    "api_app",
     "apply_event_to_graph", "ProcessingError",
     "snapshot_graph_to_file",
     "load_graph_from_file",

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -1,0 +1,60 @@
+"""Graph analytics utilities built on top of :class:`~ume.graph_adapter.IGraphAdapter`."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Dict, List, Set
+
+import networkx as nx
+
+from .graph_adapter import IGraphAdapter
+
+
+def _to_networkx(graph: IGraphAdapter) -> nx.DiGraph:
+    """Convert an ``IGraphAdapter`` implementation into a ``networkx`` graph."""
+    g = nx.DiGraph()
+    for node_id in graph.get_all_node_ids():
+        attrs = graph.get_node(node_id) or {}
+        g.add_node(node_id, **attrs)
+    for src, tgt, label in graph.get_all_edges():
+        g.add_edge(src, tgt, label=label)
+    return g
+
+
+def shortest_path(graph: IGraphAdapter, src: str, dst: str) -> List[str]:
+    """Return the shortest directed path from ``src`` to ``dst``.
+
+    If no path exists an empty list is returned.
+    """
+    g = _to_networkx(graph)
+    try:
+        return nx.shortest_path(g, src, dst)
+    except nx.NetworkXNoPath:
+        return []
+    except nx.NodeNotFound:
+        return []
+
+
+def find_communities(graph: IGraphAdapter) -> List[Set[str]]:
+    """Detect communities using a greedy modularity algorithm."""
+    g = _to_networkx(graph).to_undirected()
+    communities = nx.algorithms.community.greedy_modularity_communities(g)
+    return [set(c) for c in communities]
+
+
+def temporal_node_counts(graph: IGraphAdapter, past_n_days: int) -> Dict[str, int]:
+    """Count nodes with a ``timestamp`` attribute over the last ``past_n_days``.
+
+    The timestamp attribute is assumed to be a Unix epoch integer.
+    The return value maps ISO date strings (YYYY-MM-DD) to counts.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=past_n_days)
+    buckets: Dict[str, int] = {}
+    for node_id in graph.get_all_node_ids():
+        data = graph.get_node(node_id) or {}
+        ts = data.get("timestamp")
+        if isinstance(ts, (int, float)):
+            dt = datetime.utcfromtimestamp(int(ts))
+            if dt >= cutoff:
+                key = dt.date().isoformat()
+                buckets[key] = buckets.get(key, 0) + 1
+    return buckets

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -1,0 +1,57 @@
+"""HTTP API exposing graph queries and analytics."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from fastapi import Depends, FastAPI, HTTPException, Header
+from pydantic import BaseModel
+
+from .analytics import shortest_path
+from .graph_adapter import IGraphAdapter
+from .query import Neo4jQueryEngine
+
+API_TOKEN = os.environ.get("UME_API_TOKEN", "secret-token")
+
+app = FastAPI()
+
+# These can be configured by the embedding application or tests
+app.state.query_engine = None  # type: ignore[assignment]
+app.state.graph = None  # type: ignore[assignment]
+
+
+def require_token(authorization: str | None = Header(default=None)) -> None:
+    """Simple token-based auth using the Authorization header."""
+    if authorization is None or authorization != f"Bearer {API_TOKEN}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def get_query_engine() -> Neo4jQueryEngine:
+    engine = app.state.query_engine
+    if engine is None:
+        raise HTTPException(status_code=500, detail="Query engine not configured")
+    return engine
+
+
+def get_graph() -> IGraphAdapter:
+    graph = app.state.graph
+    if graph is None:
+        raise HTTPException(status_code=500, detail="Graph not configured")
+    return graph
+
+
+@app.get("/query")
+def run_cypher(cypher: str, _: None = Depends(require_token), engine: Neo4jQueryEngine = Depends(get_query_engine)) -> List[Dict[str, Any]]:
+    """Execute an arbitrary Cypher query and return the result set."""
+    return engine.execute_cypher(cypher)
+
+
+class ShortestPathRequest(BaseModel):
+    source: str
+    target: str
+
+
+@app.post("/analytics/shortest_path")
+def api_shortest_path(req: ShortestPathRequest, _: None = Depends(require_token), graph: IGraphAdapter = Depends(get_graph)) -> Dict[str, Any]:
+    path = shortest_path(graph, req.source, req.target)
+    return {"path": path}

--- a/src/ume/query.py
+++ b/src/ume/query.py
@@ -1,0 +1,42 @@
+"""Utilities for executing Cypher queries against a Neo4j database."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from neo4j import GraphDatabase, Driver
+
+
+class Neo4jQueryEngine:
+    """Simple wrapper around the Neo4j Bolt driver."""
+
+    def __init__(self, driver: Driver) -> None:
+        self._driver = driver
+
+    @classmethod
+    def from_credentials(cls, uri: str, user: str, password: str) -> "Neo4jQueryEngine":
+        """Instantiate the engine from connection credentials."""
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+        return cls(driver)
+
+    def close(self) -> None:
+        """Close the underlying driver connection."""
+        self._driver.close()
+
+    def execute_cypher(self, query: str, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+        """Execute an arbitrary Cypher query.
+
+        Parameters
+        ----------
+        query: str
+            The Cypher statement to execute.
+        parameters: dict, optional
+            Optional query parameters passed to Neo4j.
+
+        Returns
+        -------
+        list[dict]
+            A list of records represented as dictionaries.
+        """
+        with self._driver.session() as session:
+            result = session.run(query, parameters or {})
+            return [record.data() for record in result]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+
+from ume import MockGraph
+from ume.analytics import shortest_path, find_communities, temporal_node_counts
+
+
+def build_basic_graph():
+    g = MockGraph()
+    g.add_node("a", {})
+    g.add_node("b", {})
+    g.add_node("c", {})
+    g.add_edge("a", "b", "L")
+    g.add_edge("b", "c", "L")
+    g.add_edge("a", "c", "L")
+    return g
+
+
+def test_shortest_path():
+    g = build_basic_graph()
+    path = shortest_path(g, "a", "c")
+    assert path == ["a", "c"]
+    assert shortest_path(g, "c", "a") == []
+
+
+def test_find_communities():
+    g = build_basic_graph()
+    g.add_node("x", {})
+    g.add_node("y", {})
+    g.add_edge("x", "y", "L")
+    communities = find_communities(g)
+    # Expect two communities of sizes 3 and 2
+    sizes = sorted(len(c) for c in communities)
+    assert sizes == [2, 3]
+
+
+def test_temporal_node_counts():
+    g = MockGraph()
+    today = datetime.utcnow()
+    g.add_node("n1", {"timestamp": int(today.timestamp())})
+    g.add_node("n2", {"timestamp": int((today - timedelta(days=1)).timestamp())})
+    g.add_node("n3", {"timestamp": int((today - timedelta(days=3)).timestamp())})
+    counts = temporal_node_counts(g, 2)
+    assert len(counts) == 2
+    assert sum(counts.values()) == 2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from ume.api import app
+from ume import MockGraph
+
+
+def setup_module(_):
+    # configure app state for tests
+    app.state.query_engine = type(
+        "QE",
+        (),
+        {"execute_cypher": lambda self, q: [{"q": q}]}
+    )()
+    g = MockGraph()
+    g.add_node("a", {})
+    g.add_node("b", {})
+    g.add_edge("a", "b", "L")
+    app.state.graph = g
+
+
+def test_run_query_authorized():
+    client = TestClient(app)
+    res = client.get("/query", params={"cypher": "MATCH (n) RETURN n"}, headers={"Authorization": "Bearer secret-token"})
+    assert res.status_code == 200
+    assert res.json() == [{"q": "MATCH (n) RETURN n"}]
+
+
+def test_run_query_unauthorized():
+    client = TestClient(app)
+    res = client.get("/query", params={"cypher": "MATCH (n)"})
+    assert res.status_code == 401
+
+
+def test_shortest_path_endpoint():
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b"}
+    res = client.post("/analytics/shortest_path", json=payload, headers={"Authorization": "Bearer secret-token"})
+    assert res.status_code == 200
+    assert res.json() == {"path": ["a", "b"]}

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -18,7 +18,7 @@ def test_mockgraph_is_igraph_adapter_instance(graph: MockGraph):
 def test_add_node_success(graph: MockGraph):
     """Test adding a new node successfully."""
     node_id = "node1"
-    attributes = {"name": "Test Node", "value": 123}
+    attributes: dict[str, object] = {"name": "Test Node", "value": 123}
     graph.add_node(node_id, attributes)
     assert graph.node_exists(node_id)
     assert graph.get_node(node_id) == attributes
@@ -27,7 +27,7 @@ def test_add_node_success(graph: MockGraph):
 def test_add_node_empty_attributes_success(graph: MockGraph):
     """Test adding a new node with empty attributes successfully."""
     node_id = "node_empty_attr"
-    attributes = {}
+    attributes: dict[str, object] = {}
     graph.add_node(node_id, attributes)
     assert graph.node_exists(node_id)
     assert graph.get_node(node_id) == {}
@@ -45,8 +45,8 @@ def test_add_node_duplicate_raises_error(graph: MockGraph):
 def test_update_node_success(graph: MockGraph):
     """Test updating an existing node's attributes successfully."""
     node_id = "node1"
-    initial_attributes = {"name": "Initial Name", "version": 1}
-    update_attributes = {"version": 2, "status": "updated"}
+    initial_attributes: dict[str, object] = {"name": "Initial Name", "version": 1}
+    update_attributes: dict[str, object] = {"version": 2, "status": "updated"}
     expected_attributes = {"name": "Initial Name", "version": 2, "status": "updated"}
 
     graph.add_node(node_id, initial_attributes)
@@ -57,7 +57,7 @@ def test_update_node_success(graph: MockGraph):
 def test_update_node_with_empty_attributes_dict(graph: MockGraph):
     """Test updating with an empty attributes dictionary (should result in no change)."""
     node_id = "node1"
-    initial_attributes = {"name": "Initial Name"}
+    initial_attributes: dict[str, object] = {"name": "Initial Name"}
     graph.add_node(node_id, initial_attributes.copy()) # Add with copy
 
     graph.update_node(node_id, {}) # Update with empty dict
@@ -67,7 +67,7 @@ def test_update_node_with_empty_attributes_dict(graph: MockGraph):
 def test_update_node_non_existent_raises_error(graph: MockGraph):
     """Test that updating a non-existent node raises ProcessingError."""
     node_id = "node_not_found"
-    attributes = {"name": "Attempted Update"}
+    attributes: dict[str, object] = {"name": "Attempted Update"}
     with pytest.raises(ProcessingError, match=f"Node '{node_id}' not found for update."):
         graph.update_node(node_id, attributes)
 
@@ -75,7 +75,7 @@ def test_update_node_non_existent_raises_error(graph: MockGraph):
 def test_get_node_exists(graph: MockGraph):
     """Test get_node for an existing node."""
     node_id = "node1"
-    attributes = {"data": "some_data"}
+    attributes: dict[str, object] = {"data": "some_data"}
     graph.add_node(node_id, attributes)
     assert graph.get_node(node_id) == attributes
 
@@ -115,7 +115,7 @@ def test_clear_graph_with_nodes_and_edges(graph: MockGraph): # Renamed for clari
 def test_dump_structure(graph: MockGraph):
     """Test the basic structure of the dump method output."""
     node_id = "node1"
-    attributes = {"key": "value"}
+    attributes: dict[str, object] = {"key": "value"}
     graph.add_node(node_id, attributes)
     dump_data = graph.dump()
     assert "nodes" in dump_data

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -119,7 +119,7 @@ def test_snapshot_graph_with_nodes_roundtrip(tmp_path: pathlib.Path):
     graph = MockGraph()
     node_a_attrs = {"name": "Alice", "age": 30, "tags": ["dev", "python"]}
     node_b_attrs = {"name": "Bob", "department": "HR", "active": True}
-    node_c_attrs = {} # Node with empty attributes
+    node_c_attrs: dict[str, object] = {}  # Node with empty attributes
 
     graph.add_node("nodeA", node_a_attrs)
     graph.add_node("nodeB", node_b_attrs)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -240,16 +240,16 @@ def test_apply_create_edge_event_invalid_field_types_propagates_error(graph: Moc
     # Example: target_node_id is int
     event_bad_target_type = Event(
         event_type=EventType.CREATE_EDGE, timestamp=int(time.time()),
-        node_id="source_node", target_node_id=123, label="LINKS_TO", payload={}
-    )
+        node_id="source_node", target_node_id=123, label="LINKS_TO", payload={},  # type: ignore[arg-type]
+    )  # type: ignore[arg-type]
     with pytest.raises(ProcessingError, match="Invalid event structure for CREATE_EDGE"):
         apply_event_to_graph(event_bad_target_type, graph)
 
     # Example: label is int
     event_bad_label_type = Event(
         event_type=EventType.CREATE_EDGE, timestamp=int(time.time()),
-        node_id="source_node", target_node_id="target_node", label=456, payload={}
-    )
+        node_id="source_node", target_node_id="target_node", label=456, payload={},  # type: ignore[arg-type]
+    )  # type: ignore[arg-type]
     with pytest.raises(ProcessingError, match="Invalid event structure for CREATE_EDGE"):
         apply_event_to_graph(event_bad_label_type, graph)
 
@@ -299,7 +299,7 @@ def test_apply_delete_edge_event_invalid_field_types_propagates_error(graph: Moc
     """
     event_bad_label_type = Event(
         event_type=EventType.DELETE_EDGE, timestamp=int(time.time()),
-        node_id="s", target_node_id="t", label=123, payload={} # label is int
-    )
+        node_id="s", target_node_id="t", label=123, payload={},  # type: ignore[arg-type] # label is int
+    )  # type: ignore[arg-type]
     with pytest.raises(ProcessingError, match="Invalid event structure for DELETE_EDGE"):
         apply_event_to_graph(event_bad_label_type, graph)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,36 @@
+from ume.query import Neo4jQueryEngine
+
+
+class DummySession:
+    def __init__(self):
+        self.last = None
+
+    def run(self, query, parameters=None):
+        self.last = (query, parameters)
+        class R:
+            def __init__(self):
+                self._data = {"ok": True}
+            def data(self):
+                return self._data
+        return [R()]
+
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDriver:
+    def __init__(self):
+        self.session_obj = DummySession()
+    def session(self):
+        return self.session_obj
+    def close(self):
+        pass
+
+
+def test_execute_cypher_returns_records():
+    engine = Neo4jQueryEngine(DummyDriver())
+    result = engine.execute_cypher("MATCH (n) RETURN n")
+    assert result == [{"ok": True}]
+    assert engine._driver.session_obj.last == ("MATCH (n) RETURN n", {})


### PR DESCRIPTION
## Summary
- add Neo4jQueryEngine for Cypher queries
- implement analytics helpers (shortest path, communities, node counts)
- provide FastAPI endpoints for queries and analytics
- extend package exports
- add tests for new functionality
- configure mypy to ignore missing imports
- include new dependencies in pyproject

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d8eedfb48326b1a3e9b76af9b6ee