### PR TITLE
Add warning management flags to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `PersistentGraph` SQLite-backed adapter replacing the in-memory `MockGraph`.
 -   Automatic graph snapshotting utilities and CLI integration.
 -   Documentation describing the immutable `ume_demo` event log.
+-   `ume-cli` now accepts `--show-warnings` and `--warnings-log` for managing
+    Python warnings.
 
 ### Changed
 -   CLI and tests now use `PersistentGraph` by default.

--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ poetry run python ume_cli.py
 ```
 You will see the prompt: `ume> `. Type `help` or `?` to list available commands, or `help <command>` for details on a specific command.
 
+Pass `--show-warnings` to display Python warnings or `--warnings-log <file>` to
+log them for debugging.
+
 ### Available Commands
 
 *   **`new_node <node_id> <json_attributes>`**: Create a new node.


### PR DESCRIPTION
## Summary
- let users toggle warnings with `--show-warnings`
- allow logging warnings with `--warnings-log`
- test new CLI args and enable passing extra args in helper
- document new options in README and changelog

## Testing
- `ruff check src tests ume_cli.py`
- `mypy src ume_cli.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197af0934832699fb51d481066234