### PR TITLE
Fix unknown event type handling

### DIFF
--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -15,8 +15,13 @@ def _load_schema(event_type: str) -> Dict[str, Any]:
     """Load JSON schema for a specific event type."""
     if event_type not in _SCHEMAS:
         filename = f"{event_type.lower()}.schema.json"
-        with resources.files("ume.schemas").joinpath(filename).open("r", encoding="utf-8") as f:
-            _SCHEMAS[event_type] = json.load(f)
+        try:
+            with resources.files("ume.schemas").joinpath(filename).open(
+                "r", encoding="utf-8"
+            ) as f:
+                _SCHEMAS[event_type] = json.load(f)
+        except FileNotFoundError as exc:
+            raise ValidationError(f"Unknown event_type: {event_type}") from exc
     return _SCHEMAS[event_type]
 
 

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -1,0 +1,21 @@
+import pytest
+from jsonschema import ValidationError
+from ume.schema_utils import validate_event_dict
+
+
+def test_unknown_event_type_raises_validation_error():
+    data = {
+        "event_type": "UNKNOWN_EVENT",
+        "timestamp": 1,
+    }
+    with pytest.raises(ValidationError):
+        validate_event_dict(data)
+
+def test_validate_create_node_schema_success():
+    data = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {}
+    }
+    validate_event_dict(data)


### PR DESCRIPTION
## Summary
- raise ValidationError when `validate_event_dict` sees unknown event type
- add tests for schema validation

## Testing
- `pytest -q`
- `ruff check .`
- `mypy --ignore-missing-imports src tests` *(fails: Argument type issues in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841972465d08326b68f4b176b15ffdc