### PR TITLE
Improve config docs and logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test-and-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Check out code
         uses: actions/checkout@v4 # Updated to v4
@@ -16,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5 # Updated to v5
         with:
-          python-version: '3.12' # Matches pyproject.toml
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         run: |

--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ poetry run pytest
 PYTHONPATH=src pytest
 ```
 
+## Configuration Templates
+
+Sample configuration files for common environments are provided in
+[`docs/CONFIG_TEMPLATES.md`](docs/CONFIG_TEMPLATES.md). These templates
+demonstrate how to select different storage backends or event stores for
+development, staging, and production setups.
+
 ## Basic Usage
 
 This section outlines the basic programmatic steps to interact with the UME components using an event-driven approach. Assumes project setup is complete and services (like Redpanda, if using network-based events) are running.

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -1,0 +1,31 @@
+# Configuration Templates
+
+The following examples illustrate minimal configuration files for common environments.
+These YAML snippets are intended as starting points and can be adapted to suit
+your infrastructure.
+
+## Development
+```yaml
+db_path: ":memory:"
+event_store:
+  type: in-memory
+```
+
+## Staging
+```yaml
+db_path: staging.db
+event_store:
+  type: kafka
+  brokers:
+    - localhost:9092
+```
+
+## Production
+```yaml
+db_path: /var/lib/ume/graph.db
+event_store:
+  type: kafka
+  brokers:
+    - kafka1.prod.example.com:9092
+    - kafka2.prod.example.com:9092
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "ume", from = "src"}]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = ">=3.11,<3.13"
 confluent-kafka = ">=2.4"
 fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,7 @@
 # tests/test_event.py
 import pytest
 import time
+import logging
 from ume import Event, EventType, parse_event, EventError  # EventType constants
 
 
@@ -301,3 +302,13 @@ def test_event_creation_default_id():
     # A simple check for UUID-like structure (36 chars, with hyphens)
     assert len(event.event_id) == 36
     assert "-" in event.event_id
+
+
+def test_parse_event_logs_error(caplog):
+    """Ensure parse_event logs an error when required fields are missing."""
+    with caplog.at_level("ERROR"):
+        with pytest.raises(EventError):
+            parse_event({})
+        assert any(
+            "Missing required event field: event_type" in rec.message for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary
- support Python 3.11+ in packaging
- run CI on Python 3.11 and 3.12
- add configuration templates doc
- mention templates in README
- improve logging in `parse_event`
- test error logging in `parse_event`

## Testing
- `ruff check src/ume/event.py tests/test_event.py`
- `ruff format --check src/ume/event.py tests/test_event.py`
- `mypy src/ume/event.py tests/test_event.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419fbb2f408326a8f48fbca68db385