### PR TITLE
Add frontend and federated deployments docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Sample configuration files for common environments are provided in
 demonstrate how to select different storage backends or event stores for
 development, staging, and production setups.
 
+## Federated Deployments
+
+Running UME in multiple data centers may require synchronizing memory across
+regions. Several strategies are summarized in
+[`docs/FEDERATION.md`](docs/FEDERATION.md).
+
 ## Basic Usage
 
 This section outlines the basic programmatic steps to interact with the UME components using an event-driven approach. Assumes project setup is complete and services (like Redpanda, if using network-based events) are running.

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,0 +1,36 @@
+# Federating UME Across Data Centers
+
+This document outlines several approaches for running multiple UME deployments in different regions while keeping their graphs synchronized.
+
+## Event Log Replication
+Replicate Kafka/Redpanda topics between sites (for example via MirrorMaker or Redpanda's replication tools).
+
+**Pros**
+- Each instance processes the same event stream and converges on the same graph state.
+- Natural fit for event sourcing and allows independent recovery.
+
+**Cons**
+- Requires reliable cross-region messaging infrastructure.
+- Network latency can delay propagation of new events.
+
+## Periodic Graph Snapshots
+Periodically export the graph from one region and load it into others.
+
+**Pros**
+- Simple to implement using existing snapshot functionality.
+- Works even if event streams are not continuously replicated.
+
+**Cons**
+- Snapshots may grow large as the graph expands.
+- Merging concurrent changes from multiple regions can be complex.
+
+## Shared Distributed Database
+Use a multi-region database as the backing store for the graph (e.g., CockroachDB or Yugabyte).
+
+**Pros**
+- Single source of truth for all deployments.
+- No custom replication logic required.
+
+**Cons**
+- Depends on a distributed database with global consistency.
+- Potentially higher operational complexity and cost.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# UME Frontend
+
+This directory contains a minimal React application for visualizing a small graph.
+Open `index.html` in a browser to see sample nodes and edges rendered using the
+`vis-network` library.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>UME Graph Viewer</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      #root { height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,24 @@
+const { useEffect, useRef } = React;
+
+function Graph() {
+  const containerRef = useRef(null);
+  useEffect(() => {
+    const nodes = new vis.DataSet([
+      { id: 1, label: 'Node 1' },
+      { id: 2, label: 'Node 2' },
+      { id: 3, label: 'Node 3' },
+    ]);
+
+    const edges = new vis.DataSet([
+      { from: 1, to: 2 },
+      { from: 2, to: 3 },
+    ]);
+
+    const data = { nodes, edges };
+    const options = { physics: { stabilization: true } };
+    new vis.Network(containerRef.current, data, options);
+  }, []);
+  return React.createElement('div', { style: { height: '100%' }, ref: containerRef });
+}
+
+ReactDOM.render(React.createElement(Graph), document.getElementById('root'));


### PR DESCRIPTION
## Summary
- add a minimal React visualization under `frontend/`
- document ways to federate UME instances across data centers
- link new doc from README

## Testing
- `pip install fastapi networkx pyyaml jsonschema neo4j fastavro`
- `pip install httpx`
- `pip install -e .`
- `pytest` *(fails: CLI command sequence timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68430194cf9c832698fac0daed173bef