### PR TITLE
Add Faust stream processor

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -29,3 +29,12 @@ event_store:
     - kafka1.prod.example.com:9092
     - kafka2.prod.example.com:9092
 ```
+
+## Stream Processor
+```yaml
+faust:
+  broker: "kafka://localhost:9092"
+  input_topic: "ume_demo"
+  edge_topic: "ume_edges"
+  node_topic: "ume_nodes"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ neo4j = "*"
 networkx = "*"
 fastapi = "*"
 jsonschema = "*"
+faust-streaming = "*"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -20,6 +20,7 @@ from .snapshot import (
     SnapshotError,
 )
 from .schema_utils import validate_event_dict
+from .stream_processor import app as stream_app
 
 __all__ = [
     "Event",
@@ -45,5 +46,6 @@ __all__ = [
     "temporal_node_counts",
     "api_app",
     "validate_event_dict",
+    "stream_app",
 ]
 

--- a/src/ume/stream_processor.py
+++ b/src/ume/stream_processor.py
@@ -1,0 +1,57 @@
+"""Faust-based stream processor for UME events."""
+
+from __future__ import annotations
+
+import faust
+import json
+from typing import Dict
+
+from ume import EventType, parse_event, EventError
+
+IN_TOPIC = "ume_demo"
+EDGE_TOPIC = "ume_edges"
+NODE_TOPIC = "ume_nodes"
+
+# Map event types to destination topics
+EVENT_TOPIC_MAP: Dict[str, str] = {
+    EventType.CREATE_EDGE.value: EDGE_TOPIC,
+    EventType.CREATE_NODE.value: NODE_TOPIC,
+}
+
+
+def build_app(broker: str = "kafka://localhost:9092") -> faust.App:
+    """Create a Faust App instance."""
+    app = faust.App("ume_stream_processor", broker=broker)
+    app.conf.web_enabled = False
+
+    source_topic = app.topic(IN_TOPIC, value_type=bytes)
+    edge_topic = app.topic(EDGE_TOPIC, value_type=bytes)
+    node_topic = app.topic(NODE_TOPIC, value_type=bytes)
+
+    @app.agent(source_topic)
+    async def _process(stream):
+        async for raw in stream:
+            try:
+                data = json.loads(raw.decode("utf-8"))
+                event = parse_event(data)
+            except (ValueError, EventError, json.JSONDecodeError):
+                continue
+
+            dest = EVENT_TOPIC_MAP.get(event.event_type)
+            if dest == EDGE_TOPIC:
+                await edge_topic.send(value=raw)
+            elif dest == NODE_TOPIC:
+                await node_topic.send(value=raw)
+
+    return app
+
+
+app = build_app()
+
+
+def main() -> None:
+    app.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stream_processor.py
+++ b/tests/test_stream_processor.py
@@ -1,0 +1,52 @@
+import asyncio
+import json
+from ume.stream_processor import build_app, EDGE_TOPIC, NODE_TOPIC
+
+
+def _encoded(event: dict) -> bytes:
+    return json.dumps(event).encode()
+
+
+def test_stream_routing():
+    app = build_app("kafka://dummy")
+    agent = next(iter(app.agents.values()))
+
+    edge_topic = agent.fun.__closure__[0].cell_contents
+    node_topic = agent.fun.__closure__[1].cell_contents
+
+    edge_msgs: list[bytes] = []
+    node_msgs: list[bytes] = []
+
+    async def fake_edge_send(*, value: bytes) -> None:
+        edge_msgs.append(value)
+
+    async def fake_node_send(*, value: bytes) -> None:
+        node_msgs.append(value)
+
+    edge_topic.send = fake_edge_send
+    node_topic.send = fake_node_send
+
+    edge_event = _encoded(
+        {
+            "event_type": "CREATE_EDGE",
+            "timestamp": 1,
+            "node_id": "a",
+            "target_node_id": "b",
+            "label": "L",
+        }
+    )
+    node_event = _encoded(
+        {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    )
+
+    async def run() -> None:
+        async def agen():
+            for data in [edge_event, node_event]:
+                yield data
+
+        await agent.fun(agen())
+
+    asyncio.run(run())
+
+    assert edge_msgs == [edge_event]
+    assert node_msgs == [node_event]


### PR DESCRIPTION
## Summary
- add stream_processor using Faust to route events by type
- export stream_app in `ume.__init__`
- include faust-streaming dependency
- document broker settings in CONFIG_TEMPLATES.md
- test event routing with mocked Faust topics

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843018119fc8326b2ba30f5f6560e9f