### PR TITLE
Fix README example to call produce_event

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ event = {
 }
 
 try:
-    # Schema validation and Kafka publishing happen inside publish_event
-    client.publish_event(event)
-    print("Event published successfully")
+    # Schema validation and Kafka publishing happen inside produce_event
+    client.produce_event(event)
+    print("Event produced successfully")
 except UMEClientError as e:
-    print(f"Failed to publish event: {e}")
+    print(f"Failed to produce event: {e}")
 ```
 
 The client raises `UMEClientError` for issues such as failed validation or


### PR DESCRIPTION
## Summary
- use `UMEClient.produce_event` in README example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_684308afa0e88326a8bcf19abae0ec13