### PR TITLE
Add graph listener docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Additionally, the graph supports directed, labeled **edges** connecting these no
 For current plans and eventual detailed documentation on the UME graph model, please see:
 
 *   [**Graph Model Documentation (docs/GRAPH_MODEL.md)**](docs/GRAPH_MODEL.md)
+*   [**Graph Listener Guide (docs/GRAPH_LISTENERS.md)**](docs/GRAPH_LISTENERS.md)
 
 This documentation will be updated as the graph processing components of UME are developed.
 

--- a/docs/GRAPH_LISTENERS.md
+++ b/docs/GRAPH_LISTENERS.md
@@ -1,0 +1,56 @@
+# Graph Listeners
+
+UME exposes a simple listener interface that allows external components to react to changes in the knowledge graph.  A *GraphListener* is notified whenever nodes or edges are created, updated or deleted.  This is useful for triggering side effects (e.g. caching, analytics) without coupling that logic to the graph adapter itself.
+
+## Implementing a Listener
+
+A listener class implements the `GraphListener` protocol from `ume.listeners`.  The protocol defines four callbacks:
+
+- `on_node_created(node_id: str, attributes: dict)`
+- `on_node_updated(node_id: str, attributes: dict)`
+- `on_edge_created(source_node_id: str, target_node_id: str, label: str)`
+- `on_edge_deleted(source_node_id: str, target_node_id: str, label: str)`
+
+Each callback corresponds to an event type processed by `apply_event_to_graph`.
+
+```python
+from ume import Event, EventType, MockGraph, apply_event_to_graph
+from ume.listeners import register_listener, unregister_listener, GraphListener
+
+class MyListener:
+    def on_node_created(self, node_id: str, attributes: dict) -> None:
+        print(f"Node {node_id} created with attributes {attributes}")
+
+    def on_node_updated(self, node_id: str, attributes: dict) -> None:
+        print(f"Node {node_id} updated with {attributes}")
+
+    def on_edge_created(self, source: str, target: str, label: str) -> None:
+        print(f"Edge {label} from {source} to {target} created")
+
+    def on_edge_deleted(self, source: str, target: str, label: str) -> None:
+        print(f"Edge {label} from {source} to {target} deleted")
+
+listener = MyListener()
+register_listener(listener)
+
+# Create a node
+event = Event(EventType.CREATE_NODE, timestamp=0, payload={"node_id": "n1", "attributes": {"name": "test"}})
+apply_event_to_graph(event, MockGraph())
+
+unregister_listener(listener)
+```
+
+## Registering and Unregistering
+
+Use `register_listener()` to begin receiving callbacks and `unregister_listener()` when the listener is no longer needed.  You may register multiple listeners; each will receive every callback in the order they were registered.
+
+## Event to Callback Mapping
+
+| EventType | Callback |
+|-----------|---------|
+| `CREATE_NODE` | `on_node_created` |
+| `UPDATE_NODE_ATTRIBUTES` | `on_node_updated` |
+| `CREATE_EDGE` | `on_edge_created` |
+| `DELETE_EDGE` | `on_edge_deleted` |
+
+All callbacks are invoked **after** the graph mutation has been successfully applied.

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -27,6 +27,8 @@ from .snapshot import (
 )
 from .schema_utils import validate_event_dict
 from .stream_processor import app as stream_app
+from .plugins.alignment import PolicyViolationError
+from .audit import log_audit_entry, get_audit_entries
 
 __all__ = [
     "Event",
@@ -52,8 +54,11 @@ __all__ = [
     "temporal_node_counts",
     "api_app",
     "validate_event_dict",
+    "PolicyViolationError",
     "GraphListener",
     "register_listener",
     "unregister_listener",
+    "log_audit_entry",
+    "get_audit_entries",
 ]
 

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -2,6 +2,7 @@
 from .event import Event, EventType
 from .graph_adapter import IGraphAdapter  # Use IGraphAdapter
 from .listeners import get_registered_listeners
+from .plugins.alignment import get_plugins
 
 class ProcessingError(ValueError):
     """Custom exception for event processing errors."""


### PR DESCRIPTION
## Summary
- document GraphListener usage in new docs file
- link the listener guide from the README
- export PolicyViolationError and audit helpers
- fix processing module import for plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684308b052688326aa72afcf9242eebf