### PR TITLE
Add audit hooks for policy violations and redactions

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -18,6 +18,8 @@ from .listeners import (
     register_listener,
     unregister_listener,
 )
+from .audit import log_audit_entry, get_audit_entries
+from .plugins.alignment import PolicyViolationError
 
 from .snapshot import (
     snapshot_graph_to_file,
@@ -55,5 +57,7 @@ __all__ = [
     "GraphListener",
     "register_listener",
     "unregister_listener",
+    "log_audit_entry",
+    "get_audit_entries",
+    "PolicyViolationError",
 ]
-

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -2,6 +2,8 @@
 from .event import Event, EventType
 from .graph_adapter import IGraphAdapter  # Use IGraphAdapter
 from .listeners import get_registered_listeners
+from .plugins.alignment import get_plugins, PolicyViolationError
+
 
 class ProcessingError(ValueError):
     """Custom exception for event processing errors."""

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -1,0 +1,67 @@
+import time
+import os
+import pytest
+
+
+def test_audit_entry_on_policy_violation(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_AUDIT_LOG_PATH", str(tmp_path / "audit.log"))
+    monkeypatch.setenv("UME_AGENT_ID", "tester")
+    import importlib
+    import ume
+
+    importlib.reload(ume.audit)
+    importlib.reload(ume)
+
+    from ume import (
+        Event,
+        EventType,
+        apply_event_to_graph,
+        MockGraph,
+        get_audit_entries,
+        PolicyViolationError,
+    )
+
+    open(os.environ["UME_AUDIT_LOG_PATH"], "w").close()
+    start = len(get_audit_entries())
+
+    graph = MockGraph()
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "forbidden", "attributes": {}},
+    )
+    with pytest.raises(PolicyViolationError):
+        apply_event_to_graph(event, graph)
+    entries = get_audit_entries()
+    assert len(entries) == start + 1
+    assert entries[-1]["user_id"] == "tester"
+    assert "forbidden" in entries[-1]["reason"]
+
+
+def test_audit_entry_on_redactions(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_AUDIT_LOG_PATH", str(tmp_path / "audit.log"))
+    monkeypatch.setenv("UME_AGENT_ID", "redactor")
+    import importlib
+    import ume
+
+    importlib.reload(ume.audit)
+    importlib.reload(ume)
+
+    from ume import PersistentGraph, get_audit_entries
+
+    open(os.environ["UME_AUDIT_LOG_PATH"], "w").close()
+    start = len(get_audit_entries())
+
+    g = PersistentGraph(":memory:")
+    g.add_node("n1", {})
+    g.add_node("n2", {})
+    g.add_edge("n1", "n2", "L")
+
+    g.redact_node("n1")
+    g.redact_edge("n1", "n2", "L")
+
+    entries = get_audit_entries()
+    assert len(entries) == start + 2
+    assert entries[-2]["reason"].startswith("redact_node")
+    assert entries[-1]["reason"].startswith("redact_edge")
+    assert all(e["user_id"] == "redactor" for e in entries[-2:])


### PR DESCRIPTION
## Summary
- log audit entries when alignment plugins reject events
- add audit logging after redacting nodes or edges in `PersistentGraph`
- expose audit helpers and `PolicyViolationError` from package init
- add tests covering audit logging for policy violations and redactions

## Testing
- `pytest tests/test_audit_logging.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684308b11780832683e383e4578af31a