### PR TITLE
Remove tests cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 .pypirc
 ume_graph.db
 ume_snapshot.json
+
+# Ignore Python cache for tests
+tests/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -175,5 +175,3 @@ cython_debug/
 ume_graph.db
 ume_snapshot.json
 
-# Ignore Python cache for tests
-tests/__pycache__/


### PR DESCRIPTION
## Summary
- ignore Python cache directory in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_68446127f4a883268162b6c95697a571