### PR TITLE
Clean up duplicate imports

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -21,9 +21,6 @@ from .listeners import (
     register_listener,
     unregister_listener,
 )
-from .audit import log_audit_entry, get_audit_entries
-from .plugins.alignment import PolicyViolationError
-
 from .snapshot import (
     snapshot_graph_to_file,
     load_graph_from_file,
@@ -31,9 +28,6 @@ from .snapshot import (
     SnapshotError,
 )
 from .schema_utils import validate_event_dict
-from .stream_processor import app as stream_app
-from .plugins.alignment import PolicyViolationError
-from .audit import log_audit_entry, get_audit_entries
 
 __all__ = [
     "Event",


### PR DESCRIPTION
## Summary
- deduplicate PolicyViolationError and audit imports in `src/ume/__init__.py`

## Testing
- `pre-commit run --files src/ume/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844612867a88326afbba3e749911237