### PR TITLE
Fix graph closing on exit

### DIFF
--- a/ume_cli.py
+++ b/ume_cli.py
@@ -331,6 +331,7 @@ class UMEPrompt(Cmd):
         exit
         Quit the UME CLI.
         """
+        self.graph.close()
         print("Goodbye!")
         return True  # returning True exits the Cmd loop
 


### PR DESCRIPTION
## Summary
- close the PersistentGraph when the CLI exits

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_684461295e508326b695ba5bc3fd513a