### PR TITLE
Log warning for snapshot restore failures

### DIFF
--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -3,8 +3,11 @@ import threading
 import time
 from pathlib import Path
 from typing import Union
+import logging
 from .graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
+
+logger = logging.getLogger(__name__)
 
 
 def enable_periodic_snapshot(graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600) -> None:
@@ -34,7 +37,9 @@ def enable_snapshot_autosave_and_restore(
     if snapshot_path.is_file():
         try:
             load_graph_into_existing(graph, snapshot_path)
-        except Exception:
-            pass  # Corrupt snapshot should not prevent startup
+        except Exception as e:  # pragma: no cover - logging only
+            logger.warning(
+                "Failed to restore snapshot from %s: %s", snapshot_path, e
+            )
 
     enable_periodic_snapshot(graph, snapshot_path, interval_seconds)

--- a/tests/test_auto_snapshot.py
+++ b/tests/test_auto_snapshot.py
@@ -1,0 +1,26 @@
+import logging
+import pathlib
+from ume.auto_snapshot import enable_snapshot_autosave_and_restore
+from ume import PersistentGraph
+
+
+def test_enable_snapshot_autosave_logs_warning(tmp_path, caplog, monkeypatch):
+    snapshot_file = tmp_path / "snapshot.json"
+    snapshot_file.write_text("{}")
+    graph = PersistentGraph(":memory:")
+
+    import ume.auto_snapshot as auto_snapshot
+
+    def raise_error(*args, **kwargs):
+        raise ValueError("load error")
+
+    monkeypatch.setattr(auto_snapshot, "load_graph_into_existing", raise_error)
+    monkeypatch.setattr(auto_snapshot, "enable_periodic_snapshot", lambda *args, **kwargs: None)
+
+    with caplog.at_level(logging.WARNING):
+        auto_snapshot.enable_snapshot_autosave_and_restore(graph, snapshot_file)
+
+    assert any(
+        "Failed to restore snapshot" in rec.message for rec in caplog.records
+    )
+


### PR DESCRIPTION
## Summary
- log a warning when snapshot restoration fails in `enable_snapshot_autosave_and_restore`
- test warning behavior when snapshot restore throws

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68448af4a26483268d60c68a11691d1b