### PR TITLE
Improve token validation logic

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -22,8 +22,16 @@ app.state.graph = None  # type: ignore[assignment]
 
 def require_token(authorization: str | None = Header(default=None)) -> None:
     """Simple token-based auth using the Authorization header."""
-    if authorization is None or authorization != f"Bearer {API_TOKEN}":
-        raise HTTPException(status_code=401, detail="Unauthorized")
+    if authorization is None:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+    auth_header = authorization.strip()
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="Malformed Authorization header")
+
+    token = auth_header[7:].strip()  # len("Bearer ") == 7
+    if token != API_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid API token")
 
 
 def get_query_engine() -> Neo4jQueryEngine:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,3 +37,24 @@ def test_shortest_path_endpoint():
     res = client.post("/analytics/shortest_path", json=payload, headers={"Authorization": "Bearer secret-token"})
     assert res.status_code == 200
     assert res.json() == {"path": ["a", "b"]}
+
+
+def test_token_header_whitespace_and_case():
+    client = TestClient(app)
+    res = client.get(
+        "/query",
+        params={"cypher": "MATCH (n)"},
+        headers={"Authorization": "  bearer secret-token  "},
+    )
+    assert res.status_code == 200
+
+
+def test_malformed_authorization_header():
+    client = TestClient(app)
+    res = client.get(
+        "/query",
+        params={"cypher": "MATCH (n)"},
+        headers={"Authorization": "Token bad"},
+    )
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Malformed Authorization header"


### PR DESCRIPTION
## Summary
- handle whitespace and case-insensitive `Bearer` prefix in `require_token`
- return clearer auth errors from the API
- add tests for new header parsing logic

## Testing
- `ruff check src/ume/api.py tests/test_api.py`
- `mypy src/ume/api.py tests/test_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448af695688326b6bca432067276ef