### PR TITLE
Update agent integration example with Settings config

### DIFF
--- a/examples/agent_integration.py
+++ b/examples/agent_integration.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from ume import Event, EventType, UMEClient
+from ume.config import Settings
 
 # Configure logging so we can observe the flow
 logging.basicConfig(level=logging.INFO)
@@ -31,7 +32,8 @@ def forward_to_culture(events) -> None:
 
 
 if __name__ == "__main__":
-    client = UMEClient()
+    settings = Settings()
+    client = UMEClient(settings)
 
     # Step 1: AutoDev produces an event
     autodev_produce_event(client)
@@ -41,3 +43,4 @@ if __name__ == "__main__":
 
     # Step 3: Forward those events to Culture.ai (simulated)
     forward_to_culture(consumed)
+

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -28,6 +28,7 @@ from .snapshot import (
     SnapshotError,
 )
 from .schema_utils import validate_event_dict
+from .config import Settings
 
 __all__ = [
     "Event",
@@ -60,4 +61,5 @@ __all__ = [
     "unregister_listener",
     "log_audit_entry",
     "get_audit_entries",
+    "Settings",
 ]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+@dataclass
+class Settings:
+    """Configuration options for UME components."""
+
+    bootstrap_servers: str = "localhost:9092"
+    topic: str = "ume_demo"
+    group_id: str = "ume_client_group"
+


### PR DESCRIPTION
## Summary
- add a dataclass `Settings` in `ume.config`
- expose `Settings` via package init
- update `examples/agent_integration.py` to use `Settings` and pass it to `UMEClient`

## Testing
- `pip install -e .`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c78f254483268491d78acea0f49e