### PR TITLE
Add email anonymizer utility

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -14,6 +14,7 @@ from .query import Neo4jQueryEngine
 from .plugins.alignment import PolicyViolationError
 from .audit import log_audit_entry, get_audit_entries
 from .analytics import shortest_path, find_communities, temporal_node_counts
+from .anonymizer import anonymize_email
 from .api import app as api_app
 from .processing import apply_event_to_graph, ProcessingError
 from .listeners import (
@@ -61,5 +62,6 @@ __all__ = [
     "unregister_listener",
     "log_audit_entry",
     "get_audit_entries",
+    "anonymize_email",
     "Settings",
 ]

--- a/src/ume/anonymizer.py
+++ b/src/ume/anonymizer.py
@@ -1,0 +1,25 @@
+import hashlib
+from typing import Dict, Tuple, Any
+
+
+def anonymize_email(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    """Return a copy of payload with the email field hashed.
+
+    Parameters
+    ----------
+    payload: Dict[str, Any]
+        Dictionary possibly containing an "email" key.
+
+    Returns
+    -------
+    Tuple[Dict[str, Any], bool]
+        A tuple containing the new payload and a boolean indicating whether
+        anonymization occurred.
+    """
+    if "email" not in payload or not isinstance(payload["email"], str):
+        return payload.copy(), False
+    email = payload["email"]
+    hashed = hashlib.sha256(email.encode()).hexdigest()
+    new_payload = payload.copy()
+    new_payload["email"] = hashed
+    return new_payload, True

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -1,0 +1,8 @@
+from ume.anonymizer import anonymize_email
+
+
+def test_anonymize_email_basic():
+    payload = {"email": "user@example.com"}
+    result, flag = anonymize_email(payload)
+    assert flag is True
+    assert result["email"] == "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514"


### PR DESCRIPTION
## Summary
- create an `anonymize_email` helper that hashes the provided address
- export the helper in the package
- test anonymization behavior

## Testing
- `pip install -e .`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d5f696608326a1133ce1e17281b4