### PR TITLE
Add Kafka raw events and quarantine topics

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     KAFKA_IN_TOPIC: str = "ume_demo"
     KAFKA_EDGE_TOPIC: str = "ume_edges"
     KAFKA_NODE_TOPIC: str = "ume_nodes"
+    KAFKA_RAW_EVENTS_TOPIC: str = "ume-raw-events"
+    KAFKA_QUARANTINE_TOPIC: str = "ume-quarantine-events"
     KAFKA_GROUP_ID: str = "ume_client_group"
 
     # API


### PR DESCRIPTION
## Summary
- add `KAFKA_RAW_EVENTS_TOPIC` and `KAFKA_QUARANTINE_TOPIC` defaults
- keep `settings` singleton instantiation

## Testing
- `pre-commit run --files src/ume/config.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d6cb345083269a9902ea07c05146