### PR TITLE
Fix CLI import path order

### DIFF
--- a/ume_cli.py
+++ b/ume_cli.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 import argparse
 import json
 import logging
 import os
-from ume.config import settings
 import shlex
 import sys
 import time  # Added for timestamp in event creation
@@ -11,9 +11,13 @@ import warnings
 from pathlib import Path
 
 # Ensure local package import when run directly without installation
-sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
-from cmd import Cmd
-from ume import (
+_src_path = Path(__file__).resolve().parent / "src"
+if _src_path.exists() and str(_src_path) not in sys.path:
+    sys.path.insert(0, str(_src_path))
+
+from ume.config import settings  # noqa: E402
+from cmd import Cmd  # noqa: E402
+from ume import (  # noqa: E402
     parse_event,
     apply_event_to_graph,
     load_graph_into_existing,


### PR DESCRIPTION
## Summary
- refine `ume_cli.py` to only prepend the local `src` directory when present
- silence `ruff` E402 warnings for imports after this path modification

## Testing
- `ruff check ume_cli.py`
- `mypy ume_cli.py`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845d01379188326b48abd2b86b33ffe