### PR TITLE
Update CLI DB override and role message

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,10 @@ You will see the prompt: `ume> `. Type `help` or `?` to list available commands,
 Pass `--show-warnings` to display Python warnings or `--warnings-log <file>` to
 log them for debugging.
 
+You can set `UME_CLI_DB` to override where the CLI stores its SQLite database.
+If you define `UME_ROLE`, the CLI will run with that role's permissions and
+display an informational message at startup.
+
 ### Available Commands
 
 *   **`new_node <node_id> <json_attributes>`**: Create a new node.

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -11,4 +11,7 @@ UME_AUDIT_LOG_PATH=./audit.log
 
 # Token used by the API server for authentication
 UME_API_TOKEN=secret-token
+
+# Optional role for the CLI (leave unset for full permissions)
+UME_ROLE=view-only
 ```

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -44,13 +44,14 @@ class UMEPrompt(Cmd):
 
     def __init__(self):
         super().__init__()
-        db_path = settings.UME_DB_PATH
+        db_path = os.environ.get("UME_CLI_DB", settings.UME_DB_PATH)
         base_graph = PersistentGraph(db_path)
         role = os.environ.get("UME_ROLE")
         if role:
-            print(f"Active role: {role}")
+            print(f"INFO: UME-CLI running with role: '{role}'")
             self.graph: IGraphAdapter = RoleBasedGraphAdapter(base_graph, role)
         else:
+            print("INFO: UME-CLI running without a specific role (full permissions).")
             self.graph: IGraphAdapter = base_graph
         if db_path != ":memory:":
             enable_snapshot_autosave_and_restore(


### PR DESCRIPTION
## Summary
- make the CLI read `UME_CLI_DB` for the SQLite path
- show an informational message about the active role
- document `UME_ROLE` and how to override the DB path

## Testing
- `pre-commit run --files ume_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460b35cb808326889d83cef9180503