### PR TITLE
Add RBAC support to API startup

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from ume.api import app
+from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 
@@ -16,7 +16,7 @@ def setup_module(_):
     g.add_node("a", {})
     g.add_node("b", {})
     g.add_edge("a", "b", "L")
-    app.state.graph = g
+    configure_graph(g)
 
 
 def test_run_query_authorized():

--- a/tests/test_api_rbac.py
+++ b/tests/test_api_rbac.py
@@ -1,0 +1,51 @@
+import os
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def build_graph():
+    g = MockGraph()
+    g.add_node("a", {})
+    g.add_node("b", {})
+    g.add_edge("a", "b", "L")
+    return g
+
+
+def setup_module(_):
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+
+
+def teardown_function(_):
+    os.environ.pop("UME_API_ROLE", None)
+
+
+def test_shortest_path_allowed_for_analytics_agent():
+    os.environ["UME_API_ROLE"] = "AnalyticsAgent"
+    configure_graph(build_graph())
+
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b"}
+    res = client.post(
+        "/analytics/shortest_path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"path": ["a", "b"]}
+
+
+def test_shortest_path_forbidden_for_other_roles():
+    os.environ["UME_API_ROLE"] = "AutoDev"
+    configure_graph(build_graph())
+
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b"}
+    res = client.post(
+        "/analytics/shortest_path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- allow configuring API graph with RoleBasedGraphAdapter via new `configure_graph` helper
- enforce role checks on analytics via updated BFS shortest path
- handle `AccessDeniedError` as HTTP 403
- test API RBAC behavior

## Testing
- `ruff check .`
- `mypy --python-version=3.12 src/ume/api.py src/ume/analytics.py tests/test_api.py tests/test_api_rbac.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460b36b67083268361c4915562fb6e