### PR TITLE
Implement privacy filter and topic updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 -   `PersistentGraph` SQLite-backed adapter replacing the in-memory `MockGraph`.
 -   Automatic graph snapshotting utilities and CLI integration.
--   Documentation describing the immutable `ume_demo` event log.
+-   Documentation describing the immutable `ume-clean-events` event log.
 -   `ume-cli` now accepts `--show-warnings` and `--warnings-log` for managing
     Python warnings.
 

--- a/Dockerfile.privacy-agent
+++ b/Dockerfile.privacy-agent
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install poetry
+COPY pyproject.toml poetry.lock ./
+RUN poetry install --no-root --no-dev
+RUN poetry run python -m spacy download en_core_web_lg
+COPY src/ /app/src
+ENV PYTHONPATH=/app
+CMD ["poetry", "run", "python", "src/ume/privacy_agent.py"]

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The current system consists of the following main components:
     *   Redpanda is a Kafka-compatible streaming data platform. It is run locally using Docker, as defined in the `docker/docker-compose.yml` file.
     *   It receives events from producers and stores them durably in topics.
     *   It allows multiple consumers to subscribe to these topics and read events.
-    *   The demo uses a topic named `ume_demo`, configured for unlimited retention and immutable append-only storage so it acts as the canonical audit trail.
+    *   The demo uses a topic named `ume-clean-events`, configured for unlimited retention and immutable append-only storage so it acts as the canonical audit trail.
     *   The Docker setup also includes Redpanda Console, which provides a UI and schema registry capabilities, accessible typically on `localhost:8081` (for the console) while Redpanda itself exposes a schema registry via Pandaproxy on `localhost:8082`.
 
 3.  **Event Consumer (`src/ume/consumer_demo.py`):**
     *   This script subscribes to topics on the message broker to receive and process events.
-    *   In the demo, it connects to the Kafka/Redpanda broker at `localhost:9092`, subscribes to the `ume_demo` topic using the group ID `ume_demo_group`.
+    *   In the demo, it connects to the Kafka/Redpanda broker at `localhost:9092`, subscribes to the `ume-clean-events` topic using the group ID `ume_client_group`.
     *   Upon receiving an event, it logs the event's content. In a more complete system, this component would be responsible for parsing the event, updating the memory graph, triggering actions, or other processing tasks.
 
 ### Event Schema
@@ -119,9 +119,9 @@ Used to remove a specific directed, labeled edge between two nodes.
 
 The basic data flow is as follows:
 
-*   The `producer_demo.py` script sends an event to the `ume_demo` topic in Redpanda.
+*   The `producer_demo.py` script sends an event to the `ume-raw-events` topic in Redpanda.
 *   Redpanda stores this event.
-*   The `consumer_demo.py` script, subscribed to the `ume_demo` topic, receives this event from Redpanda.
+*   The `consumer_demo.py` script, subscribed to the `ume-clean-events` topic, receives this event from Redpanda.
 *   The consumer then processes the event (currently, by logging it).
 
 This setup demonstrates a simple event-driven architecture, which is foundational for the UME concept where events are captured and processed to build up a knowledge graph or memory representation.
@@ -235,7 +235,7 @@ See [docs/SSL_SETUP.md](docs/SSL_SETUP.md) for details.
 ```bash
 poetry run python src/ume/consumer_demo.py
 ```
-This script subscribes to topic `ume_demo` on `localhost:9092` and waits for messages.
+This script subscribes to topic `ume-clean-events` on `localhost:9092` and waits for messages.
 
 ### 4. Run the Producer Demo
 ```bash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,3 +85,11 @@ services:
       # Let's simplify and assume Redpanda Console exposes schema registry functionality
       # through its main port (8080 internally) when connected to Redpanda.
       # The user's requirement "schema-registry ... on localhost:8081" will be met by this.
+
+  privacy-agent:
+    build:
+      context: ..
+      dockerfile: Dockerfile.privacy-agent
+    depends_on:
+      redpanda:
+        condition: service_healthy

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -46,7 +46,7 @@ event_store:
 ```yaml
 faust:
   broker: "kafka://localhost:9092"
-  input_topic: "ume_demo"
+  input_topic: "ume-clean-events"
   edge_topic: "ume_edges"
   node_topic: "ume_nodes"
 ```

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     # Kafka/Redpanda
     KAFKA_BOOTSTRAP_SERVERS: str = "localhost:9092"
     KAFKA_RAW_EVENTS_TOPIC: str = "ume-raw-events"
-    KAFKA_IN_TOPIC: str = "ume_demo"
+    KAFKA_CLEAN_EVENTS_TOPIC: str = "ume-clean-events"
     KAFKA_QUARANTINE_TOPIC: str = "ume-quarantine-events"
     KAFKA_EDGE_TOPIC: str = "ume_edges"
     KAFKA_NODE_TOPIC: str = "ume_nodes"

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("consumer_demo")
 # Kafka broker and topic
 # Set KAFKA_CA_CERT, KAFKA_CLIENT_CERT and KAFKA_CLIENT_KEY to enable TLS.
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
-TOPIC = settings.KAFKA_IN_TOPIC
+TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 GROUP_ID = settings.KAFKA_GROUP_ID
 
 

--- a/src/ume/privacy_agent.py
+++ b/src/ume/privacy_agent.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 RAW_TOPIC = settings.KAFKA_RAW_EVENTS_TOPIC
-IN_TOPIC = settings.KAFKA_IN_TOPIC
+CLEAN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 QUARANTINE_TOPIC = settings.KAFKA_QUARANTINE_TOPIC
 GROUP_ID = settings.KAFKA_PRIVACY_AGENT_GROUP_ID
 
@@ -106,7 +106,9 @@ def run_privacy_agent() -> None:
             data["payload"] = redacted_payload
 
             try:
-                producer.produce(IN_TOPIC, value=json.dumps(data).encode("utf-8"))
+                producer.produce(
+                    CLEAN_TOPIC, value=json.dumps(data).encode("utf-8")
+                )
             except KafkaException as exc:
                 logger.error("Failed to produce sanitized event: %s", exc)
 

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("producer_demo")
 # Kafka broker and topic
 # Set KAFKA_CA_CERT, KAFKA_CLIENT_CERT and KAFKA_CLIENT_KEY to enable TLS.
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
-TOPIC = settings.KAFKA_IN_TOPIC
+TOPIC = settings.KAFKA_RAW_EVENTS_TOPIC
 
 
 def ssl_config() -> dict:

--- a/src/ume/stream_processor.py
+++ b/src/ume/stream_processor.py
@@ -9,7 +9,7 @@ from typing import Dict
 from ume import EventType, parse_event, EventError
 from .config import settings
 
-IN_TOPIC = settings.KAFKA_IN_TOPIC
+IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
 NODE_TOPIC = settings.KAFKA_NODE_TOPIC
 

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,5 +1,6 @@
 from presidio_analyzer import RecognizerResult
 from ume import privacy_agent
+import json
 
 
 class FakeAnalyzer:
@@ -25,3 +26,72 @@ def test_redact_event_payload_without_pii(monkeypatch):
     redacted, flag = privacy_agent.redact_event_payload(payload)
     assert flag is False
     assert redacted == payload
+
+
+class FakeMessage:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def error(self):
+        return None
+
+
+class FakeConsumer:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def poll(self, timeout=1.0):
+        if self._messages:
+            return self._messages.pop(0)
+        raise KeyboardInterrupt
+
+    def subscribe(self, topics):
+        pass
+
+    def close(self):
+        pass
+
+
+class FakeProducer:
+    def __init__(self):
+        self.produced = []
+
+    def produce(self, topic, value, *args, **kwargs):
+        self.produced.append((topic, value))
+
+    def flush(self):
+        pass
+
+
+def test_privacy_agent_end_to_end(monkeypatch):
+    payload = {"email": "user@example.com"}
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": payload,
+    }
+    msg = FakeMessage(json.dumps(event).encode("utf-8"))
+
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    results = [RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)]
+
+    monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer(results))
+    monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
+    monkeypatch.setattr(privacy_agent, "log_audit_entry", lambda *a, **k: None)
+
+    privacy_agent.run_privacy_agent()
+
+    clean_topic = privacy_agent.CLEAN_TOPIC
+    quarantine_topic = privacy_agent.QUARANTINE_TOPIC
+
+    clean_msg = next(val for (topic, val) in producer.produced if topic == clean_topic)
+    quarantine_msg = next(val for (topic, val) in producer.produced if topic == quarantine_topic)
+
+    assert json.loads(clean_msg.decode("utf-8"))["payload"] == {"email": "<EMAIL_ADDRESS>"}
+    assert json.loads(quarantine_msg.decode("utf-8")) == {"original": payload}


### PR DESCRIPTION
## Summary
- rename KAFKA_IN_TOPIC to KAFKA_CLEAN_EVENTS_TOPIC and update consumers/producers
- add privacy agent Dockerfile and docker-compose service
- adjust docs to use the new topics
- add integration test for privacy agent

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846db8be47c832683f3961babc3a1eb