### PR TITLE
Add traversal APIs and query helpers

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -14,6 +14,7 @@ from .query import Neo4jQueryEngine
 from .plugins.alignment import PolicyViolationError
 from .audit import log_audit_entry, get_audit_entries
 from .analytics import shortest_path, find_communities, temporal_node_counts
+from . import query_helpers
 from .anonymizer import anonymize_email
 from .api import app as api_app
 from .processing import apply_event_to_graph, ProcessingError
@@ -55,6 +56,7 @@ __all__ = [
     "find_communities",
     "temporal_node_counts",
     "api_app",
+    "query_helpers",
     "validate_event_dict",
     "PolicyViolationError",
     "GraphListener",

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -189,9 +189,7 @@ class MockGraph(IGraphAdapter):
 
         connected_nodes: List[str] = []
         for target, lbl in self._edges.get(node_id, []):
-            if (
-                edge_label is None or lbl == edge_label
-            ) and (
+            if (edge_label is None or lbl == edge_label) and (
                 node_id not in self._redacted_nodes
                 and target not in self._redacted_nodes
                 and (node_id, target, lbl) not in self._redacted_edges
@@ -258,3 +256,87 @@ class MockGraph(IGraphAdapter):
     def close(self) -> None:
         """Mock adapter does not hold resources."""
         pass
+
+    # ---- Traversal and pathfinding ---------------------------------
+
+    def shortest_path(self, source_id: str, target_id: str) -> List[str]:
+        if not self.node_exists(source_id) or not self.node_exists(target_id):
+            return []
+        visited = {source_id: None}
+        queue: List[str] = [source_id]
+        while queue:
+            current = queue.pop(0)
+            if current == target_id:
+                break
+            for neighbor in self.find_connected_nodes(current):
+                if neighbor not in visited:
+                    visited[neighbor] = current
+                    queue.append(neighbor)
+        if target_id not in visited:
+            return []
+        path = [target_id]
+        while visited[path[-1]] is not None:
+            prev = visited[path[-1]]
+            assert prev is not None
+            path.append(prev)
+        path.reverse()
+        return path
+
+    def traverse(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+    ) -> List[str]:
+        if not self.node_exists(start_node_id):
+            raise ProcessingError(f"Node '{start_node_id}' not found.")
+        visited: set[str] = {start_node_id}
+        queue: List[tuple[str, int]] = [(start_node_id, 0)]
+        result: List[str] = []
+        while queue:
+            node, d = queue.pop(0)
+            if d >= depth:
+                continue
+            for neighbor in self.find_connected_nodes(node, edge_label):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    result.append(neighbor)
+                    queue.append((neighbor, d + 1))
+        return result
+
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        nodes: Dict[str, Dict[str, Any]] = {}
+        edges: List[Tuple[str, str, str]] = []
+        to_visit = [(start_node_id, 0)]
+        visited: set[str] = set()
+        while to_visit:
+            node, d = to_visit.pop(0)
+            if node in visited or d > depth:
+                continue
+            visited.add(node)
+            data = self.get_node(node) or {}
+            include = True
+            if since_timestamp is not None:
+                ts = data.get("timestamp")
+                if ts is None or int(ts) < since_timestamp:
+                    include = False
+            if include:
+                nodes[node] = data.copy()
+            if d == depth:
+                continue
+            for tgt, lbl in self._edges.get(node, []):
+                if lbl == edge_label or edge_label is None:
+                    if (
+                        node not in self._redacted_nodes
+                        and tgt not in self._redacted_nodes
+                        and (node, tgt, lbl) not in self._redacted_edges
+                    ):
+                        edges.append((node, tgt, lbl))
+                        to_visit.append((tgt, d + 1))
+        return {"nodes": nodes, "edges": edges}

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -199,3 +199,43 @@ class IGraphAdapter(ABC):
     def close(self) -> None:
         """Release any resources held by the graph adapter."""
         pass
+
+    # ---- Traversal and pathfinding -------------------------------------
+
+    @abstractmethod
+    def shortest_path(self, source_id: str, target_id: str) -> list[str]:
+        """Return the shortest path from ``source_id`` to ``target_id``.
+
+        Implementations should return an empty list if no path exists.
+        """
+
+    @abstractmethod
+    def traverse(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+    ) -> list[str]:
+        """Traverse outward from ``start_node_id`` up to ``depth`` hops.
+
+        ``edge_label`` may be used to restrict traversal to edges with the
+        given label. The return value is a list of visited node IDs in BFS
+        order.
+        """
+
+    @abstractmethod
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary describing a subgraph rooted at ``start_node_id``.
+
+        ``since_timestamp`` filters nodes to those whose ``timestamp`` attribute
+        is greater than or equal to the given epoch integer.
+        The returned dictionary must contain ``nodes`` and ``edges`` keys using
+        the same structure as :meth:`dump`.
+        """
+        pass

--- a/src/ume/query_helpers.py
+++ b/src/ume/query_helpers.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .graph_adapter import IGraphAdapter
+
+
+def shortest_path(graph: IGraphAdapter, source: str, target: str) -> List[str]:
+    """Wrapper around :meth:`IGraphAdapter.shortest_path`."""
+    return graph.shortest_path(source, target)
+
+
+def traverse(
+    graph: IGraphAdapter,
+    start_node_id: str,
+    depth: int,
+    edge_label: Optional[str] = None,
+) -> List[str]:
+    """Wrapper around :meth:`IGraphAdapter.traverse`."""
+    return graph.traverse(start_node_id, depth, edge_label)
+
+
+def extract_subgraph(
+    graph: IGraphAdapter,
+    start_node_id: str,
+    depth: int,
+    edge_label: Optional[str] = None,
+    since_timestamp: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Wrapper around :meth:`IGraphAdapter.extract_subgraph`."""
+    return graph.extract_subgraph(start_node_id, depth, edge_label, since_timestamp)

--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -1,4 +1,5 @@
 """Role-based wrapper around IGraphAdapter."""
+
 from typing import Dict, Any, Optional
 
 from .graph_adapter import IGraphAdapter
@@ -52,7 +53,9 @@ class RoleBasedGraphAdapter(IGraphAdapter):
     def get_all_node_ids(self) -> list[str]:
         return self._adapter.get_all_node_ids()
 
-    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> list[str]:
+    def find_connected_nodes(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> list[str]:
         self._require_analytics_role()
         return self._adapter.find_connected_nodes(node_id, edge_label)
 
@@ -73,3 +76,30 @@ class RoleBasedGraphAdapter(IGraphAdapter):
 
     def close(self) -> None:
         self._adapter.close()
+
+    # ---- Traversal and pathfinding ---------------------------------
+
+    def shortest_path(self, source_id: str, target_id: str) -> list[str]:
+        self._require_analytics_role()
+        return self._adapter.shortest_path(source_id, target_id)
+
+    def traverse(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+    ) -> list[str]:
+        self._require_analytics_role()
+        return self._adapter.traverse(start_node_id, depth, edge_label)
+
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        self._require_analytics_role()
+        return self._adapter.extract_subgraph(
+            start_node_id, depth, edge_label, since_timestamp
+        )

--- a/tests/test_traversal_methods.py
+++ b/tests/test_traversal_methods.py
@@ -1,0 +1,34 @@
+from ume import MockGraph
+
+
+def build_graph():
+    g = MockGraph()
+    g.add_node("a", {"timestamp": 1})
+    g.add_node("b", {"timestamp": 2})
+    g.add_node("c", {"timestamp": 3})
+    g.add_node("d", {"timestamp": 4})
+    g.add_edge("a", "b", "L")
+    g.add_edge("b", "c", "L")
+    g.add_edge("a", "d", "L")
+    return g
+
+
+def test_shortest_path_method():
+    g = build_graph()
+    assert g.shortest_path("a", "c") == ["a", "b", "c"]
+    assert g.shortest_path("c", "a") == []
+
+
+def test_traverse_method():
+    g = build_graph()
+    result = g.traverse("a", depth=2)
+    assert set(result) == {"b", "d", "c"}
+
+
+def test_extract_subgraph():
+    g = build_graph()
+    sub = g.extract_subgraph("a", depth=1)
+    assert set(sub["nodes"].keys()) == {"a", "b", "d"}
+    assert len(sub["edges"]) == 2
+    recent = g.extract_subgraph("a", depth=2, since_timestamp=3)
+    assert set(recent["nodes"].keys()) == {"c", "d"}


### PR DESCRIPTION
## Summary
- support pathfinding and subgraph extraction in `IGraphAdapter`
- implement default traversal logic in `MockGraph`, `PersistentGraph`, and `Neo4jGraph`
- expose new SDK helpers via `query_helpers`
- enforce traversal permissions in `RoleBasedGraphAdapter`
- test new traversal methods

## Testing
- `poetry run ruff format src/ume/__init__.py src/ume/graph.py src/ume/graph_adapter.py src/ume/neo4j_graph.py src/ume/persistent_graph.py src/ume/rbac_adapter.py src/ume/query_helpers.py tests/test_traversal_methods.py`
- `poetry run ruff check src/ume/__init__.py src/ume/graph.py src/ume/graph_adapter.py src/ume/neo4j_graph.py src/ume/persistent_graph.py src/ume/rbac_adapter.py src/ume/query_helpers.py tests/test_traversal_methods.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477773ba0c832694747d74137c1b2c