### PR TITLE
Add constrained path search with new API endpoints

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -15,6 +15,7 @@ from .plugins.alignment import PolicyViolationError
 from .audit import log_audit_entry, get_audit_entries
 from .analytics import shortest_path, find_communities, temporal_node_counts
 from . import query_helpers
+from . import graph_queries
 from .anonymizer import anonymize_email
 from .api import app as api_app
 from .processing import apply_event_to_graph, ProcessingError
@@ -58,6 +59,7 @@ __all__ = [
     "temporal_node_counts",
     "api_app",
     "query_helpers",
+    "graph_queries",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -340,3 +340,41 @@ class MockGraph(IGraphAdapter):
                         edges.append((node, tgt, lbl))
                         to_visit.append((tgt, d + 1))
         return {"nodes": nodes, "edges": edges}
+
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: int | None = None,
+        edge_label: str | None = None,
+        since_timestamp: int | None = None,
+    ) -> list[str]:
+        if not self.node_exists(source_id) or not self.node_exists(target_id):
+            return []
+        visited: dict[str, str | None] = {source_id: None}
+        queue: list[tuple[str, int]] = [(source_id, 0)]
+        while queue:
+            node, depth = queue.pop(0)
+            if node == target_id:
+                break
+            if max_depth is not None and depth >= max_depth:
+                continue
+            for neighbor in self.find_connected_nodes(node, edge_label):
+                if neighbor in visited:
+                    continue
+                if since_timestamp is not None:
+                    data = self.get_node(neighbor) or {}
+                    ts = data.get("timestamp")
+                    if ts is None or int(ts) < since_timestamp:
+                        continue
+                visited[neighbor] = node
+                queue.append((neighbor, depth + 1))
+        if target_id not in visited:
+            return []
+        path = [target_id]
+        while visited[path[-1]] is not None:
+            prev = visited[path[-1]]
+            assert prev is not None
+            path.append(prev)
+        path.reverse()
+        return path

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -239,3 +239,22 @@ class IGraphAdapter(ABC):
         the same structure as :meth:`dump`.
         """
         pass
+
+    @abstractmethod
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: Optional[int] = None,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> list[str]:
+        """Return a path from ``source_id`` to ``target_id`` using constraints.
+
+        If ``max_depth`` is provided the search will stop after that many hops.
+        ``edge_label`` restricts traversal to edges with the given label and
+        ``since_timestamp`` requires all visited nodes to have a ``timestamp``
+        attribute greater than or equal to the provided value.  Implementations
+        must return an empty list when no path satisfies the constraints.
+        """
+        pass

--- a/src/ume/graph_queries.py
+++ b/src/ume/graph_queries.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .graph_adapter import IGraphAdapter
+
+
+def constrained_path(
+    graph: IGraphAdapter,
+    source: str,
+    target: str,
+    max_depth: Optional[int] = None,
+    edge_label: Optional[str] = None,
+    since_timestamp: Optional[int] = None,
+) -> List[str]:
+    """Find a path between two nodes honoring optional constraints."""
+    return graph.constrained_path(
+        source, target, max_depth, edge_label, since_timestamp
+    )
+
+
+def subgraph(
+    graph: IGraphAdapter,
+    start_node_id: str,
+    depth: int,
+    edge_label: Optional[str] = None,
+    since_timestamp: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Convenience wrapper around :meth:`IGraphAdapter.extract_subgraph`."""
+    return graph.extract_subgraph(start_node_id, depth, edge_label, since_timestamp)
+
+
+def neighbors(
+    graph: IGraphAdapter, node_id: str, edge_label: Optional[str] = None
+) -> List[str]:
+    """Return connected nodes using :meth:`IGraphAdapter.find_connected_nodes`."""
+    return graph.find_connected_nodes(node_id, edge_label)

--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -1,6 +1,6 @@
 """Role-based wrapper around IGraphAdapter."""
 
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 from .graph_adapter import IGraphAdapter
 
@@ -102,4 +102,17 @@ class RoleBasedGraphAdapter(IGraphAdapter):
         self._require_analytics_role()
         return self._adapter.extract_subgraph(
             start_node_id, depth, edge_label, since_timestamp
+        )
+
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: int | None = None,
+        edge_label: str | None = None,
+        since_timestamp: int | None = None,
+    ) -> List[str]:
+        self._require_analytics_role()
+        return self._adapter.constrained_path(
+            source_id, target_id, max_depth, edge_label, since_timestamp
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,9 +8,7 @@ from ume.config import settings
 def setup_module(_):
     # configure app state for tests
     app.state.query_engine = type(
-        "QE",
-        (),
-        {"execute_cypher": lambda self, q: [{"q": q}]}
+        "QE", (), {"execute_cypher": lambda self, q: [{"q": q}]}
     )()
     g = MockGraph()
     g.add_node("a", {})
@@ -21,7 +19,11 @@ def setup_module(_):
 
 def test_run_query_authorized():
     client = TestClient(app)
-    res = client.get("/query", params={"cypher": "MATCH (n) RETURN n"}, headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"})
+    res = client.get(
+        "/query",
+        params={"cypher": "MATCH (n) RETURN n"},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
     assert res.status_code == 200
     assert res.json() == [{"q": "MATCH (n) RETURN n"}]
 
@@ -35,9 +37,37 @@ def test_run_query_unauthorized():
 def test_shortest_path_endpoint():
     client = TestClient(app)
     payload = {"source": "a", "target": "b"}
-    res = client.post("/analytics/shortest_path", json=payload, headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"})
+    res = client.post(
+        "/analytics/shortest_path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
     assert res.status_code == 200
     assert res.json() == {"path": ["a", "b"]}
+
+
+def test_constrained_path_endpoint():
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b", "max_depth": 1}
+    res = client.post(
+        "/analytics/path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"path": ["a", "b"]}
+
+
+def test_subgraph_endpoint():
+    client = TestClient(app)
+    payload = {"start": "a", "depth": 1}
+    res = client.post(
+        "/analytics/subgraph",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert set(res.json()["nodes"].keys()) == {"a", "b"}
 
 
 def test_token_header_whitespace_and_case():

--- a/tests/test_api_rbac.py
+++ b/tests/test_api_rbac.py
@@ -37,6 +37,30 @@ def test_shortest_path_allowed_for_analytics_agent():
     assert res.json() == {"path": ["a", "b"]}
 
 
+def test_path_and_subgraph_allowed_for_analytics_agent():
+    os.environ["UME_API_ROLE"] = "AnalyticsAgent"
+    configure_graph(build_graph())
+
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b"}
+    res = client.post(
+        "/analytics/path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"path": ["a", "b"]}
+
+    sub = {"start": "a", "depth": 1}
+    res = client.post(
+        "/analytics/subgraph",
+        json=sub,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert set(res.json()["nodes"].keys()) == {"a", "b"}
+
+
 def test_shortest_path_forbidden_for_other_roles():
     os.environ["UME_API_ROLE"] = "AutoDev"
     configure_graph(build_graph())
@@ -46,6 +70,21 @@ def test_shortest_path_forbidden_for_other_roles():
     res = client.post(
         "/analytics/shortest_path",
         json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+
+    res = client.post(
+        "/analytics/path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+
+    sub = {"start": "a", "depth": 1}
+    res = client.post(
+        "/analytics/subgraph",
+        json=sub,
         headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
     )
     assert res.status_code == 403

--- a/tests/test_traversal_methods.py
+++ b/tests/test_traversal_methods.py
@@ -32,3 +32,11 @@ def test_extract_subgraph():
     assert len(sub["edges"]) == 2
     recent = g.extract_subgraph("a", depth=2, since_timestamp=3)
     assert set(recent["nodes"].keys()) == {"c", "d"}
+
+
+def test_constrained_path():
+    g = build_graph()
+    assert g.constrained_path("a", "c", max_depth=2) == ["a", "b", "c"]
+    assert g.constrained_path("a", "c", max_depth=1) == []
+    assert g.constrained_path("a", "c", edge_label="X") == []
+    assert g.constrained_path("a", "c", since_timestamp=3) == []


### PR DESCRIPTION
## Summary
- extend `IGraphAdapter` with `constrained_path`
- implement constrained path search in graph adapters
- expose helpers in new `graph_queries` module
- add REST endpoints `/analytics/path` and `/analytics/subgraph`
- test new query helpers and RBAC checks

## Testing
- `ruff check src/ume/__init__.py src/ume/api.py src/ume/graph.py src/ume/graph_adapter.py src/ume/neo4j_graph.py src/ume/persistent_graph.py src/ume/rbac_adapter.py src/ume/graph_queries.py tests/test_api.py tests/test_api_rbac.py tests/test_traversal_methods.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'ume' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68477d1645a48326929e73381e7040a2