### PR TITLE
Add graph similarity analytics and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,20 @@ print(recent)
 If GDS is not available or another adapter is used, these functions fall back to
 `networkx` implementations.
 
+### Graph Similarity
+
+You can also measure how similar two graphs are using `graph_similarity`:
+
+```python
+from ume import Neo4jGraph
+from ume.analytics import graph_similarity
+
+g1 = Neo4jGraph("bolt://localhost:7687", "neo4j", "password", use_gds=True)
+g2 = Neo4jGraph("bolt://localhost:7687", "neo4j", "password", use_gds=True)
+score = graph_similarity(g1, g2)
+print(score)
+```
+
 ## Where to Get Help
 
 If you have questions, encounter issues, or want to discuss ideas related to UME, please feel free to:

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -19,6 +19,10 @@ from .analytics import (
     temporal_node_counts,
     temporal_community_detection,
     time_varying_centrality,
+    pagerank_centrality,
+    betweenness_centrality,
+    node_similarity,
+    graph_similarity,
 )
 from . import query_helpers
 from . import graph_queries
@@ -63,6 +67,10 @@ __all__ = [
     "Neo4jQueryEngine",
     "shortest_path",
     "find_communities",
+    "pagerank_centrality",
+    "betweenness_centrality",
+    "node_similarity",
+    "graph_similarity",
     "temporal_node_counts",
     "temporal_community_detection",
     "time_varying_centrality",

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -105,6 +105,22 @@ def node_similarity(graph: IGraphAdapter) -> List[tuple[str, str, float]]:
     return [(u, v, p) for u, v, p in nx.jaccard_coefficient(g)]
 
 
+def graph_similarity(graph1: IGraphAdapter, graph2: IGraphAdapter) -> float:
+    """Return a Jaccard similarity score between two graphs."""
+    db_method = getattr(graph1, "graph_similarity", None)
+    if callable(db_method) and type(graph1) is type(graph2):
+        try:
+            return db_method(graph2)
+        except NotImplementedError:
+            pass
+
+    edges1 = set(graph1.get_all_edges())
+    edges2 = set(graph2.get_all_edges())
+    if not edges1 and not edges2:
+        return 1.0
+    return len(edges1 & edges2) / len(edges1 | edges2)
+
+
 def temporal_node_counts(graph: IGraphAdapter, past_n_days: int) -> Dict[str, int]:
     """Count nodes with a ``timestamp`` attribute over the last ``past_n_days``.
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -10,6 +10,7 @@ from ume.analytics import (
     pagerank_centrality,
     betweenness_centrality,
     node_similarity,
+    graph_similarity,
 )
 
 
@@ -58,9 +59,11 @@ def test_centrality_and_similarity():
     pr = pagerank_centrality(g)
     bc = betweenness_centrality(g)
     sims = node_similarity(g)
+    sim_score = graph_similarity(g, g)
     assert set(pr) == {"a", "b", "c"}
     assert set(bc) == {"a", "b", "c"}
     assert all(len(t) == 3 for t in sims)
+    assert sim_score == 1.0
 
 
 def test_temporal_algorithms():

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -70,7 +70,7 @@ def test_add_node_duplicate_raises():
 
 
 def test_gds_methods_issue_queries():
-    results = [[], [], [], [], [], []]
+    results = [[], [], [], [], [], [], []]
     driver = DummyDriver(results)
     graph = Neo4jGraph(
         "bolt://localhost:7687",
@@ -84,6 +84,7 @@ def test_gds_methods_issue_queries():
     graph.betweenness_centrality()
     graph.community_detection()
     graph.node_similarity()
+    graph.graph_similarity(graph)
     graph.temporal_community_detection(5)
     graph.time_varying_centrality(5)
 
@@ -92,5 +93,6 @@ def test_gds_methods_issue_queries():
     assert "gds.betweenness.stream" in queries[1]
     assert "gds.louvain.stream" in queries[2]
     assert "gds.nodeSimilarity.stream" in queries[3]
-    assert "gds.beta.temporalClustering.stream" in queries[4]
-    assert "gds.beta.timeWeightedPageRank.stream" in queries[5]
+    assert "gds.beta.temporalClustering.stream" in queries[-2]
+    assert "gds.beta.timeWeightedPageRank.stream" in queries[-1]
+    assert len(queries) >= 7


### PR DESCRIPTION
## Summary
- integrate a new `graph_similarity` analytic with NetworkX fallback
- expose extra analytic helpers from the package
- support graph similarity in `Neo4jGraph`
- document new feature in README
- update unit tests for analytics and Neo4j graph

## Testing
- `ruff check src/ume/__init__.py src/ume/analytics.py src/ume/neo4j_graph.py tests/test_analytics.py tests/test_neo4j_graph.py`
- `ruff format --check src/ume/__init__.py src/ume/analytics.py src/ume/neo4j_graph.py tests/test_analytics.py tests/test_neo4j_graph.py`
- `pytest -q tests/test_analytics.py tests/test_neo4j_graph.py` *(fails: ModuleNotFoundError: No module named 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_68482d5f675c83268b9528e89d15de60