### PR TITLE
Refactor graph traversal utilities

### DIFF
--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -2,9 +2,10 @@
 from typing import Dict, Any, Optional, List, Tuple, DefaultDict
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
+from .graph_algorithms import GraphAlgorithmsMixin
 
 
-class MockGraph(IGraphAdapter):
+class MockGraph(GraphAlgorithmsMixin, IGraphAdapter):
     """
     A simple mock graph representation implementing IGraphAdapter, for testing.
 
@@ -257,124 +258,3 @@ class MockGraph(IGraphAdapter):
         """Mock adapter does not hold resources."""
         pass
 
-    # ---- Traversal and pathfinding ---------------------------------
-
-    def shortest_path(self, source_id: str, target_id: str) -> List[str]:
-        if not self.node_exists(source_id) or not self.node_exists(target_id):
-            return []
-        visited: Dict[str, Optional[str]] = {source_id: None}
-        queue: List[str] = [source_id]
-        while queue:
-            current = queue.pop(0)
-            if current == target_id:
-                break
-            for neighbor in self.find_connected_nodes(current):
-                if neighbor not in visited:
-                    visited[neighbor] = current
-                    queue.append(neighbor)
-        if target_id not in visited:
-            return []
-        path = [target_id]
-        while visited[path[-1]] is not None:
-            prev = visited[path[-1]]
-            assert prev is not None
-            path.append(prev)
-        path.reverse()
-        return path
-
-    def traverse(
-        self,
-        start_node_id: str,
-        depth: int,
-        edge_label: Optional[str] = None,
-    ) -> List[str]:
-        if not self.node_exists(start_node_id):
-            raise ProcessingError(f"Node '{start_node_id}' not found.")
-        visited: set[str] = {start_node_id}
-        queue: List[tuple[str, int]] = [(start_node_id, 0)]
-        result: List[str] = []
-        while queue:
-            node, d = queue.pop(0)
-            if d >= depth:
-                continue
-            for neighbor in self.find_connected_nodes(node, edge_label):
-                if neighbor not in visited:
-                    visited.add(neighbor)
-                    result.append(neighbor)
-                    queue.append((neighbor, d + 1))
-        return result
-
-    def extract_subgraph(
-        self,
-        start_node_id: str,
-        depth: int,
-        edge_label: Optional[str] = None,
-        since_timestamp: Optional[int] = None,
-    ) -> Dict[str, Any]:
-        nodes: Dict[str, Dict[str, Any]] = {}
-        edges: List[Tuple[str, str, str]] = []
-        to_visit = [(start_node_id, 0)]
-        visited: set[str] = set()
-        while to_visit:
-            node, d = to_visit.pop(0)
-            if node in visited or d > depth:
-                continue
-            visited.add(node)
-            data = self.get_node(node) or {}
-            include = True
-            if since_timestamp is not None:
-                ts = data.get("timestamp")
-                if ts is None or int(ts) < since_timestamp:
-                    include = False
-            if include:
-                nodes[node] = data.copy()
-            if d == depth:
-                continue
-            for tgt, lbl in self._edges.get(node, []):
-                if lbl == edge_label or edge_label is None:
-                    if (
-                        node not in self._redacted_nodes
-                        and tgt not in self._redacted_nodes
-                        and (node, tgt, lbl) not in self._redacted_edges
-                    ):
-                        edges.append((node, tgt, lbl))
-                        to_visit.append((tgt, d + 1))
-        return {"nodes": nodes, "edges": edges}
-
-    def constrained_path(
-        self,
-        source_id: str,
-        target_id: str,
-        max_depth: int | None = None,
-        edge_label: str | None = None,
-        since_timestamp: int | None = None,
-    ) -> list[str]:
-        if not self.node_exists(source_id) or not self.node_exists(target_id):
-            return []
-        visited: dict[str, str | None] = {source_id: None}
-        queue: list[tuple[str, int]] = [(source_id, 0)]
-        while queue:
-            node, depth = queue.pop(0)
-            if node == target_id:
-                break
-            if max_depth is not None and depth >= max_depth:
-                continue
-            for neighbor in self.find_connected_nodes(node, edge_label):
-                if neighbor in visited:
-                    continue
-                if since_timestamp is not None:
-                    data = self.get_node(neighbor) or {}
-                    ts = data.get("timestamp")
-                    if ts is None or int(ts) < since_timestamp:
-                        continue
-                visited[neighbor] = node
-                queue.append((neighbor, depth + 1))
-        if target_id not in visited:
-            return []
-        path = [target_id]
-        while visited[path[-1]] is not None:
-            prev = visited[path[-1]]
-            assert prev is not None
-            path.append(prev)
-        path.reverse()
-        return path

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from .processing import ProcessingError
+
+
+class GraphAlgorithmsMixin:
+    """Reusable traversal and path finding methods for graph adapters."""
+
+    def shortest_path(self, source_id: str, target_id: str) -> List[str]:
+        if not self.node_exists(source_id) or not self.node_exists(target_id):
+            return []
+        visited: Dict[str, Optional[str]] = {source_id: None}
+        queue: List[str] = [source_id]
+        while queue:
+            current = queue.pop(0)
+            if current == target_id:
+                break
+            for neighbor in self.find_connected_nodes(current):
+                if neighbor not in visited:
+                    visited[neighbor] = current
+                    queue.append(neighbor)
+        if target_id not in visited:
+            return []
+        path = [target_id]
+        while visited[path[-1]] is not None:
+            prev = visited[path[-1]]
+            assert prev is not None
+            path.append(prev)
+        path.reverse()
+        return path
+
+    def traverse(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+    ) -> List[str]:
+        if not self.node_exists(start_node_id):
+            raise ProcessingError(f"Node '{start_node_id}' not found.")
+        visited: set[str] = {start_node_id}
+        queue: List[tuple[str, int]] = [(start_node_id, 0)]
+        result: List[str] = []
+        while queue:
+            node, d = queue.pop(0)
+            if d >= depth:
+                continue
+            for neighbor in self.find_connected_nodes(node, edge_label):
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    result.append(neighbor)
+                    queue.append((neighbor, d + 1))
+        return result
+
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        nodes: Dict[str, Dict[str, Any]] = {}
+        edges: List[Tuple[str, str, str]] = []
+        adj: Dict[str, List[Tuple[str, str]]] = {}
+        for src, tgt, lbl in self.get_all_edges():
+            adj.setdefault(src, []).append((tgt, lbl))
+
+        to_visit = [(start_node_id, 0)]
+        visited: set[str] = set()
+        while to_visit:
+            node, d = to_visit.pop(0)
+            if node in visited or d > depth:
+                continue
+            visited.add(node)
+            data = self.get_node(node) or {}
+            include = True
+            if since_timestamp is not None:
+                ts = data.get("timestamp")
+                if ts is None or int(ts) < since_timestamp:
+                    include = False
+            if include:
+                nodes[node] = data.copy()
+            if d == depth:
+                continue
+            for tgt, lbl in adj.get(node, []):
+                if edge_label is None or lbl == edge_label:
+                    edges.append((node, tgt, lbl))
+                    to_visit.append((tgt, d + 1))
+        return {"nodes": nodes, "edges": edges}
+
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: Optional[int] = None,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> List[str]:
+        if not self.node_exists(source_id) or not self.node_exists(target_id):
+            return []
+        visited: Dict[str, Optional[str]] = {source_id: None}
+        queue: List[tuple[str, int]] = [(source_id, 0)]
+        while queue:
+            node, depth = queue.pop(0)
+            if node == target_id:
+                break
+            if max_depth is not None and depth >= max_depth:
+                continue
+            for neighbor in self.find_connected_nodes(node, edge_label):
+                if neighbor in visited:
+                    continue
+                if since_timestamp is not None:
+                    data = self.get_node(neighbor) or {}
+                    ts = data.get("timestamp")
+                    if ts is None or int(ts) < since_timestamp:
+                        continue
+                visited[neighbor] = node
+                queue.append((neighbor, depth + 1))
+        if target_id not in visited:
+            return []
+        path = [target_id]
+        while visited[path[-1]] is not None:
+            prev = visited[path[-1]]
+            assert prev is not None
+            path.append(prev)
+        path.reverse()
+        return path

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -5,9 +5,10 @@ from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .audit import log_audit_entry
 from .config import settings
+from .graph_algorithms import GraphAlgorithmsMixin
 
 
-class PersistentGraph(IGraphAdapter):
+class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
     """SQLite-backed persistent graph implementation."""
 
     def __init__(self, db_path: str | None = None) -> None:
@@ -188,124 +189,3 @@ class PersistentGraph(IGraphAdapter):
             f"redact_edge {source_node_id} {target_node_id} {label}",
         )
 
-    # ---- Traversal and pathfinding ---------------------------------
-
-    def shortest_path(self, source_id: str, target_id: str) -> List[str]:
-        if not self.node_exists(source_id) or not self.node_exists(target_id):
-            return []
-        visited: Dict[str, Optional[str]] = {source_id: None}
-        queue: List[str] = [source_id]
-        while queue:
-            current = queue.pop(0)
-            if current == target_id:
-                break
-            for neighbor in self.find_connected_nodes(current):
-                if neighbor not in visited:
-                    visited[neighbor] = current
-                    queue.append(neighbor)
-        if target_id not in visited:
-            return []
-        path = [target_id]
-        while visited[path[-1]] is not None:
-            prev = visited[path[-1]]
-            assert prev is not None
-            path.append(prev)
-        path.reverse()
-        return path
-
-    def traverse(
-        self,
-        start_node_id: str,
-        depth: int,
-        edge_label: Optional[str] = None,
-    ) -> List[str]:
-        if not self.node_exists(start_node_id):
-            raise ProcessingError(f"Node '{start_node_id}' not found.")
-        visited: set[str] = {start_node_id}
-        queue: List[tuple[str, int]] = [(start_node_id, 0)]
-        result: List[str] = []
-        while queue:
-            node, d = queue.pop(0)
-            if d >= depth:
-                continue
-            for neighbor in self.find_connected_nodes(node, edge_label):
-                if neighbor not in visited:
-                    visited.add(neighbor)
-                    result.append(neighbor)
-                    queue.append((neighbor, d + 1))
-        return result
-
-    def extract_subgraph(
-        self,
-        start_node_id: str,
-        depth: int,
-        edge_label: Optional[str] = None,
-        since_timestamp: Optional[int] = None,
-    ) -> Dict[str, Any]:
-        nodes: Dict[str, Dict[str, Any]] = {}
-        edges: List[Tuple[str, str, str]] = []
-        all_edges = self.get_all_edges()
-        adj: Dict[str, List[Tuple[str, str]]] = {}
-        for src, tgt, lbl in all_edges:
-            adj.setdefault(src, []).append((tgt, lbl))
-
-        to_visit = [(start_node_id, 0)]
-        visited: set[str] = set()
-        while to_visit:
-            node, d = to_visit.pop(0)
-            if node in visited or d > depth:
-                continue
-            visited.add(node)
-            data = self.get_node(node) or {}
-            include = True
-            if since_timestamp is not None:
-                ts = data.get("timestamp")
-                if ts is None or int(ts) < since_timestamp:
-                    include = False
-            if include:
-                nodes[node] = data.copy()
-            if d == depth:
-                continue
-            for tgt, lbl in adj.get(node, []):
-                if edge_label is None or lbl == edge_label:
-                    edges.append((node, tgt, lbl))
-                    to_visit.append((tgt, d + 1))
-        return {"nodes": nodes, "edges": edges}
-
-    def constrained_path(
-        self,
-        source_id: str,
-        target_id: str,
-        max_depth: int | None = None,
-        edge_label: str | None = None,
-        since_timestamp: int | None = None,
-    ) -> List[str]:
-        if not self.node_exists(source_id) or not self.node_exists(target_id):
-            return []
-        visited: dict[str, str | None] = {source_id: None}
-        queue: List[tuple[str, int]] = [(source_id, 0)]
-        while queue:
-            node, depth = queue.pop(0)
-            if node == target_id:
-                break
-            if max_depth is not None and depth >= max_depth:
-                continue
-            for neighbor in self.find_connected_nodes(node, edge_label):
-                if neighbor in visited:
-                    continue
-                if since_timestamp is not None:
-                    data = self.get_node(neighbor) or {}
-                    ts = data.get("timestamp")
-                    if ts is None or int(ts) < since_timestamp:
-                        continue
-                visited[neighbor] = node
-                queue.append((neighbor, depth + 1))
-        if target_id not in visited:
-            return []
-        path = [target_id]
-        while visited[path[-1]] is not None:
-            prev = visited[path[-1]]
-            assert prev is not None
-            path.append(prev)
-        path.reverse()
-        return path


### PR DESCRIPTION
## Summary
- centralize path-related algorithms in `GraphAlgorithmsMixin`
- derive `MockGraph`, `PersistentGraph`, and `Neo4jGraph` from the mixin
- drop duplicated traversal logic from adapters
- handle missing SciPy by providing a NumPy-based PageRank fallback
- avoid extra DB query in Neo4j `graph_similarity`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848649c6b8083269a868f44a4e7516e