### PR TITLE
Implement batching for Kafka producer

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -22,8 +22,8 @@ class Settings(BaseSettings):
     KAFKA_NODE_TOPIC: str = "ume_nodes"
     KAFKA_GROUP_ID: str = "ume_client_group"
     KAFKA_PRIVACY_AGENT_GROUP_ID: str = "ume-privacy-agent-group"
-    # Flush interval for Kafka producer in privacy agent
-    KAFKA_PRODUCER_FLUSH_INTERVAL: int = 1
+    # Number of messages to batch before calling `Producer.flush()` in the privacy agent
+    KAFKA_PRODUCER_BATCH_SIZE: int = 10
 
     # API
     UME_API_TOKEN: str = "secret-token"

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -8,6 +8,21 @@ from .processing import ProcessingError
 class GraphAlgorithmsMixin:
     """Reusable traversal and path finding methods for graph adapters."""
 
+    # These methods are expected to be provided by the implementing graph adapter
+    def node_exists(self, node_id: str) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def find_connected_nodes(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> List[str]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def get_all_edges(self) -> List[Tuple[str, str, str]]:  # pragma: no cover
+        raise NotImplementedError
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:  # pragma: no cover
+        raise NotImplementedError
+
     def shortest_path(self, source_id: str, target_id: str) -> List[str]:
         if not self.node_exists(source_id) or not self.node_exists(target_id):
             return []

--- a/src/ume/privacy_agent.py
+++ b/src/ume/privacy_agent.py
@@ -26,7 +26,7 @@ RAW_TOPIC = settings.KAFKA_RAW_EVENTS_TOPIC
 CLEAN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 QUARANTINE_TOPIC = settings.KAFKA_QUARANTINE_TOPIC
 GROUP_ID = settings.KAFKA_PRIVACY_AGENT_GROUP_ID
-FLUSH_INTERVAL = settings.KAFKA_PRODUCER_FLUSH_INTERVAL
+BATCH_SIZE = settings.KAFKA_PRODUCER_BATCH_SIZE
 
 # Initialize Presidio engines
 _ANALYZER = AnalyzerEngine()
@@ -128,7 +128,7 @@ def run_privacy_agent() -> None:
                     logger.error("Failed to produce quarantine event: %s", exc)
                 user_id = settings.UME_AGENT_ID
                 log_audit_entry(user_id, f"payload_redacted {data.get('event_id')}")
-            if pending >= FLUSH_INTERVAL:
+            if pending >= BATCH_SIZE:
                 producer.flush()
                 pending = 0
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- batch messages in privacy agent
- add KAFKA_PRODUCER_BATCH_SIZE setting
- improve mypy stubs for graph algorithms mixin
- test flushing behavior with batched producer

## Testing
- `pre-commit run --files src/ume/config.py src/ume/privacy_agent.py src/ume/graph_algorithms.py tests/test_privacy_agent.py`
- `pytest -q` *(fails: ImportError: cannot import name 'EventType' from 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_684985175bdc8326b05b8366b4384970