### PR TITLE
Add Poetry cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
           # Disables creation of a new virtual environment by Poetry within the project directory for CI
           # --local flag makes this configuration specific to the current project
 
+      - name: Cache Poetry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
+
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
         run: |

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -12,6 +12,7 @@ from .graph_adapter import IGraphAdapter
 from .rbac_adapter import RoleBasedGraphAdapter, AccessDeniedError
 from .plugins.alignment import PolicyViolationError
 from .processing import apply_event_to_graph, ProcessingError
+from .audit import log_audit_entry, get_audit_entries
 from .snapshot import (
     snapshot_graph_to_file,
     load_graph_from_file,
@@ -49,4 +50,6 @@ __all__ = [
     "DEFAULT_SCHEMA_MANAGER",
     "PolicyViolationError",
     "Settings",
+    "log_audit_entry",
+    "get_audit_entries",
 ]

--- a/src/ume/_internal/listeners.py
+++ b/src/ume/_internal/listeners.py
@@ -12,10 +12,14 @@ class GraphListener(Protocol):
     def on_node_updated(self, node_id: str, attributes: Dict[str, Any]) -> None:
         """Called after a node's attributes are updated."""
 
-    def on_edge_created(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def on_edge_created(
+        self, source_node_id: str, target_node_id: str, label: str
+    ) -> None:
         """Called after an edge is created."""
 
-    def on_edge_deleted(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def on_edge_deleted(
+        self, source_node_id: str, target_node_id: str, label: str
+    ) -> None:
         """Called after an edge is deleted."""
 
 

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -40,7 +40,7 @@ def _pagerank_numpy(
     A = nx.to_numpy_array(g, nodelist=nodes, weight="weight", dtype=float)
     S = A.sum(axis=1)
     S[S != 0] = 1.0 / S[S != 0]
-    A = (S[:, None] * A)
+    A = S[:, None] * A
 
     x = np.repeat(1.0 / n, n)
     p = x.copy()

--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -10,7 +10,9 @@ from .snapshot import snapshot_graph_to_file, load_graph_into_existing
 logger = logging.getLogger(__name__)
 
 
-def enable_periodic_snapshot(graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600) -> None:
+def enable_periodic_snapshot(
+    graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600
+) -> None:
     """Enable periodic snapshotting and snapshot on shutdown."""
     snapshot_path = Path(path)
 
@@ -38,8 +40,6 @@ def enable_snapshot_autosave_and_restore(
         try:
             load_graph_into_existing(graph, snapshot_path)
         except Exception as e:  # pragma: no cover - logging only
-            logger.warning(
-                "Failed to restore snapshot from %s: %s", snapshot_path, e
-            )
+            logger.warning("Failed to restore snapshot from %s: %s", snapshot_path, e)
 
     enable_periodic_snapshot(graph, snapshot_path, interval_seconds)

--- a/src/ume/client.py
+++ b/src/ume/client.py
@@ -58,7 +58,9 @@ class UMEClient:
         except ValidationError as e:
             logger.error("Event validation failed: %s", e.message)
             raise UMEClientError(f"Event validation failed: {e.message}") from e
-        except Exception as e:  # pragma: no cover - confluent_kafka may raise various errors
+        except (
+            Exception
+        ) as e:  # pragma: no cover - confluent_kafka may raise various errors
             logger.error("Failed to produce event: %s", e)
             raise UMEClientError(f"Failed to produce event: {e}") from e
 

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -86,9 +86,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         raise EventError("Missing required event field: event_type")
     event_type = data["event_type"]
     if not isinstance(event_type, str):
-        msg = (
-            f"Invalid type for 'event_type': expected str, got {type(event_type).__name__}"
-        )
+        msg = f"Invalid type for 'event_type': expected str, got {type(event_type).__name__}"
         logger.error(msg)
         raise EventError(msg)
 
@@ -117,9 +115,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
             logger.error(msg)
             raise EventError(msg)
         if not isinstance(node_id_val, str):
-            msg = (
-                f"Invalid type for 'node_id' in {event_type} event: expected str, got {type(node_id_val).__name__}"
-            )
+            msg = f"Invalid type for 'node_id' in {event_type} event: expected str, got {type(node_id_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 
@@ -130,9 +126,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         # Ensure payload_val (which could be the default {} if "payload" key was missing,
         # or the actual value if present) is a dict for these event types.
         if not isinstance(payload_val, dict):
-            msg = (
-                f"Invalid type for 'payload' in {event_type} event: expected dict, got {type(payload_val).__name__}"
-            )
+            msg = f"Invalid type for 'payload' in {event_type} event: expected dict, got {type(payload_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 
@@ -140,9 +134,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         required_fields_for_edge = {"node_id", "target_node_id", "label"}
         missing_fields = required_fields_for_edge - data.keys()
         if missing_fields:
-            msg = (
-                f"Missing required fields for {event_type} event: {', '.join(sorted(list(missing_fields)))}"
-            )
+            msg = f"Missing required fields for {event_type} event: {', '.join(sorted(list(missing_fields)))}"
             logger.error(msg)
             raise EventError(msg)
 
@@ -155,18 +147,14 @@ def parse_event(data: Dict[str, Any]) -> Event:
             if not isinstance(
                 field_val_check, str
             ):  # Already checked for presence by missing_fields logic
-                msg = (
-                    f"Invalid type for '{field_name}' in {event_type} event: expected str, got {type(field_val_check).__name__}"
-                )
+                msg = f"Invalid type for '{field_name}' in {event_type} event: expected str, got {type(field_val_check).__name__}"
                 logger.error(msg)
                 raise EventError(msg)
 
         # For edge events, payload_val will use its default {} if "payload" was not in data.
         # If "payload" was in data, we still need to ensure it's a dict.
         if "payload" in data and not isinstance(payload_val, dict):
-            msg = (
-                f"Invalid type for 'payload' in {event_type} event (if provided): expected dict, got {type(payload_val).__name__}"
-            )
+            msg = f"Invalid type for 'payload' in {event_type} event (if provided): expected dict, got {type(payload_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -257,4 +257,3 @@ class MockGraph(GraphAlgorithmsMixin, IGraphAdapter):
     def close(self) -> None:
         """Mock adapter does not hold resources."""
         pass
-

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -9,7 +9,6 @@ import json
 import yaml  # type: ignore
 
 
-
 @dataclass
 class NodeType:
     """Representation of a node type within the graph schema."""
@@ -51,7 +50,9 @@ class GraphSchema:
             for label, info in data.get("edge_labels", {}).items()
         }
         version = str(data.get("version", "0.0.0"))
-        return GraphSchema(version=version, node_types=node_types, edge_labels=edge_labels)
+        return GraphSchema(
+            version=version, node_types=node_types, edge_labels=edge_labels
+        )
 
     @classmethod
     def load_default(cls) -> "GraphSchema":

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -208,7 +208,6 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
             )
             return {rec["id"]: rec["score"] for rec in result}
 
-
     def community_detection(self) -> List[set[str]]:
         self._ensure_gds_enabled()
         with self._driver.session() as session:

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -188,4 +188,3 @@ class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
             user_id,
             f"redact_edge {source_node_id} {target_node_id} {label}",
         )
-

--- a/src/ume/plugins/alignment/__init__.py
+++ b/src/ume/plugins/alignment/__init__.py
@@ -1,4 +1,5 @@
 """Alignment plugin interface and registry."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/ume/plugins/alignment/sample_policy.py
+++ b/src/ume/plugins/alignment/sample_policy.py
@@ -8,7 +8,10 @@ class DenyForbiddenNode(AlignmentPlugin):
     """Reject CREATE_NODE events for the special node_id 'forbidden'."""
 
     def validate(self, event: Event) -> None:
-        if event.event_type == EventType.CREATE_NODE and event.payload.get("node_id") == "forbidden":
+        if (
+            event.event_type == EventType.CREATE_NODE
+            and event.payload.get("node_id") == "forbidden"
+        ):
             raise PolicyViolationError("Creation of node_id 'forbidden' is not allowed")
 
 

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -8,13 +8,16 @@ from .graph_schema import load_default_schema
 
 DEFAULT_VERSION = load_default_schema().version
 
+
 class ProcessingError(ValueError):
     """Custom exception for event processing errors."""
 
     pass
 
 
-def apply_event_to_graph(event: Event, graph: IGraphAdapter, *, schema_version: str = DEFAULT_VERSION) -> None:
+def apply_event_to_graph(
+    event: Event, graph: IGraphAdapter, *, schema_version: str = DEFAULT_VERSION
+) -> None:
     """
     Applies an event to a graph, modifying the graph based on event type and payload.
 

--- a/src/ume/query.py
+++ b/src/ume/query.py
@@ -1,4 +1,5 @@
 """Utilities for executing Cypher queries against a Neo4j database."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
@@ -22,7 +23,9 @@ class Neo4jQueryEngine:
         """Close the underlying driver connection."""
         self._driver.close()
 
-    def execute_cypher(self, query: str, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def execute_cypher(
+        self, query: str, parameters: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
         """Execute an arbitrary Cypher query.
 
         Parameters

--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -19,7 +19,9 @@ class GraphSchemaManager:
         pkg = resources.files("ume.schemas")
         for path in pkg.iterdir():
             name = path.name
-            if name.startswith("graph_schema") and name.endswith((".yaml", ".yml", ".json")):
+            if name.startswith("graph_schema") and name.endswith(
+                (".yaml", ".yml", ".json")
+            ):
                 schema = GraphSchema.load(str(path))
                 self._schemas[schema.version] = schema
 

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -1,4 +1,5 @@
 """Utilities for validating UME events against JSON Schemas."""
+
 from __future__ import annotations
 
 import json
@@ -16,9 +17,11 @@ def _load_schema(event_type: str) -> Dict[str, Any]:
     if event_type not in _SCHEMAS:
         filename = f"{event_type.lower()}.schema.json"
         try:
-            with resources.files("ume.schemas").joinpath(filename).open(
-                "r", encoding="utf-8"
-            ) as f:
+            with (
+                resources.files("ume.schemas")
+                .joinpath(filename)
+                .open("r", encoding="utf-8") as f
+            ):
                 _SCHEMAS[event_type] = json.load(f)
         except FileNotFoundError as exc:
             raise ValidationError(f"Unknown event_type: {event_type}") from exc
@@ -32,4 +35,3 @@ def validate_event_dict(event_data: Dict[str, Any]) -> None:
         raise ValidationError("event_type missing or not a string")
     schema = _load_schema(event_type)
     validate(instance=event_data, schema=schema)
-

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -14,8 +14,9 @@ class SnapshotError(ValueError):
     pass
 
 
-def snapshot_graph_to_file(graph: IGraphAdapter, path: Union[str, pathlib.Path]) -> None:
-
+def snapshot_graph_to_file(
+    graph: IGraphAdapter, path: Union[str, pathlib.Path]
+) -> None:
     """
     Snapshots the given graph's current state to a JSON file.
 
@@ -136,7 +137,9 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
     return graph
 
 
-def load_graph_into_existing(graph: IGraphAdapter, path: Union[str, pathlib.Path]) -> None:
+def load_graph_into_existing(
+    graph: IGraphAdapter, path: Union[str, pathlib.Path]
+) -> None:
     """Load snapshot data from ``path`` into an existing graph adapter."""
     loaded = load_graph_from_file(path)
     graph.clear()

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -5,4 +5,7 @@ def test_anonymize_email_basic():
     payload = {"email": "user@example.com"}
     result, flag = anonymize_email(payload)
     assert flag is True
-    assert result["email"] == "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514"
+    assert (
+        result["email"]
+        == "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514"
+    )

--- a/tests/test_auto_snapshot.py
+++ b/tests/test_auto_snapshot.py
@@ -13,12 +13,11 @@ def test_enable_snapshot_autosave_logs_warning(tmp_path, caplog, monkeypatch):
         raise ValueError("load error")
 
     monkeypatch.setattr(auto_snapshot, "load_graph_into_existing", raise_error)
-    monkeypatch.setattr(auto_snapshot, "enable_periodic_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        auto_snapshot, "enable_periodic_snapshot", lambda *args, **kwargs: None
+    )
 
     with caplog.at_level(logging.WARNING):
         auto_snapshot.enable_snapshot_autosave_and_restore(graph, snapshot_file)
 
-    assert any(
-        "Failed to restore snapshot" in rec.message for rec in caplog.records
-    )
-
+    assert any("Failed to restore snapshot" in rec.message for rec in caplog.records)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -135,12 +135,12 @@ def test_cli_redact_node_and_edge():
     commands = [
         'new_node n1 "{}"',
         'new_node n2 "{}"',
-        'new_edge n1 n2 L',
-        'redact_node n1',
-        'redact_edge n1 n2 L',
-        'show_nodes',
-        'show_edges',
-        'exit',
+        "new_edge n1 n2 L",
+        "redact_node n1",
+        "redact_edge n1 n2 L",
+        "show_nodes",
+        "show_edges",
+        "exit",
     ]
     stdout, stderr, rc = run_cli_commands(commands)
     assert "Node 'n1' redacted." in stdout

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -309,5 +309,6 @@ def test_parse_event_logs_error(caplog):
         with pytest.raises(EventError):
             parse_event({})
         assert any(
-            "Missing required event field: event_type" in rec.message for rec in caplog.records
+            "Missing required event field: event_type" in rec.message
+            for rec in caplog.records
         )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -11,10 +11,12 @@ from ume.graph_adapter import IGraphAdapter  # Import for isinstance check if ne
 
 # Fixture for a clean MockGraph instance
 
+
 @pytest.fixture
 def graph() -> PersistentGraph:
     """Provides a clean PersistentGraph (in-memory) instance for each test."""
     return PersistentGraph(":memory:")
+
 
 def test_mockgraph_is_igraph_adapter_instance(graph: MockGraph):
     """Test that MockGraph is an instance of IGraphAdapter."""
@@ -85,7 +87,6 @@ def test_update_node_non_existent_raises_error(graph: PersistentGraph):
     with pytest.raises(
         ProcessingError, match=f"Node '{node_id}' not found for update."
     ):
-
         graph.update_node(node_id, attributes)
 
 
@@ -147,7 +148,6 @@ def test_dump_structure(graph: PersistentGraph):
 
 
 def test_dump_empty_graph_structure(graph: MockGraph):
-
     """Test dump structure for an empty graph."""
     dump_data = graph.dump()
     assert "nodes" in dump_data
@@ -196,7 +196,6 @@ def test_add_edge_missing_source_node_raises_error(graph: MockGraph):
 
 
 def test_add_edge_missing_target_node_raises_error(graph: MockGraph):
-
     """Test ProcessingError when adding an edge with a non-existent target node."""
     graph.add_node("nodeS", {})  # Source node exists
     with pytest.raises(
@@ -207,7 +206,6 @@ def test_add_edge_missing_target_node_raises_error(graph: MockGraph):
 
 
 def test_add_edge_both_nodes_missing_raises_error(graph: MockGraph):
-
     """Test ProcessingError when adding an edge with both source and target nodes non-existent."""
     with pytest.raises(
         ProcessingError,
@@ -223,7 +221,6 @@ def test_get_all_edges_empty_graph(graph: PersistentGraph):
 
 
 def test_get_all_edges_no_edges_but_nodes_exist(graph: MockGraph):
-
     """Test get_all_edges on a graph with nodes but no edges."""
     graph.add_node("node1", {})
     graph.add_node("node2", {})
@@ -231,7 +228,6 @@ def test_get_all_edges_no_edges_but_nodes_exist(graph: MockGraph):
 
 
 def test_get_all_edges_populated(graph: MockGraph):
-
     """Test get_all_edges on a graph with multiple edges."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -257,7 +253,6 @@ def test_get_all_edges_populated(graph: MockGraph):
 
 
 def test_find_connected_nodes_non_existent_node_raises_error(graph: MockGraph):
-
     """
     Test find_connected_nodes for a non-existent node.
     Should raise ProcessingError.
@@ -296,7 +291,6 @@ def test_find_connected_nodes_with_edges(graph: MockGraph):
 
 
 def test_find_connected_nodes_no_matching_edges(graph: MockGraph):
-
     """Test find_connected_nodes when no outgoing edges match."""
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -326,7 +320,6 @@ def test_delete_edge_success(graph: PersistentGraph):
 
 
 def test_delete_multiple_edges(graph: MockGraph):
-
     """Test deleting one edge when multiple exist."""
     graph.add_node("s", {})
     graph.add_node("t1", {})
@@ -349,7 +342,6 @@ def test_delete_multiple_edges(graph: MockGraph):
 
 
 def test_delete_edge_non_existent_raises_error(graph: MockGraph):
-
     """Test that attempting to delete a non-existent edge raises ProcessingError."""
     graph.add_node("s1", {})
     graph.add_node("t1", {})
@@ -362,7 +354,6 @@ def test_delete_edge_non_existent_raises_error(graph: MockGraph):
 
 
 def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph):
-
     """
     Test deleting an edge where source node doesn't exist.
     (PersistentGraph.delete_edge currently doesn't check node existence, only edge tuple).
@@ -376,7 +367,6 @@ def test_delete_edge_non_existent_source_node_implicitly_fails(graph: MockGraph)
 
 
 def test_delete_edge_non_existent_target_node_implicitly_fails(graph: MockGraph):
-
     """
     Test deleting an edge where target node doesn't exist.
     (Similar to above, fails due to edge tuple not found).

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -142,7 +142,6 @@ def test_snapshot_graph_with_nodes_roundtrip(tmp_path: pathlib.Path):
     node_b_attrs = {"name": "Bob", "department": "HR", "active": True}
     node_c_attrs: dict[str, object] = {}  # Node with empty attributes
 
-
     graph.add_node("nodeA", node_a_attrs)
     graph.add_node("nodeB", node_b_attrs)
     graph.add_node("nodeC", node_c_attrs)

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,38 +1,8 @@
-import importlib.util
 import json
-from pathlib import Path
-import sys
-import types
 
 from presidio_analyzer import RecognizerResult
 
-root_dir = Path(__file__).resolve().parents[1]
-# Build a minimal 'ume' package so privacy_agent can be imported
-pkg = types.ModuleType("ume")
-pkg.__path__ = [str(root_dir / "src/ume")]
-sys.modules["ume"] = pkg
-
-schemas_spec = importlib.util.spec_from_file_location(
-    "ume.schemas",
-    root_dir / "src/ume/schemas/__init__.py",
-    submodule_search_locations=[str(root_dir / "src/ume/schemas")],
-)
-assert schemas_spec is not None
-schemas_mod = importlib.util.module_from_spec(schemas_spec)
-assert schemas_spec.loader is not None
-sys.modules["ume.schemas"] = schemas_mod
-schemas_spec.loader.exec_module(schemas_mod)
-
-pa_spec = importlib.util.spec_from_file_location(
-    "ume.privacy_agent",
-    root_dir / "src/ume/privacy_agent.py",
-    submodule_search_locations=[str(root_dir / "src/ume")],
-)
-assert pa_spec is not None
-privacy_agent = importlib.util.module_from_spec(pa_spec)
-assert pa_spec.loader is not None
-sys.modules["ume.privacy_agent"] = privacy_agent
-pa_spec.loader.exec_module(privacy_agent)
+from ume import privacy_agent
 
 
 class FakeAnalyzer:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -19,7 +19,6 @@ def graph() -> PersistentGraph:
 
 
 def test_apply_create_node_event_success(graph: MockGraph):
-
     """Test successfully creating a new node."""
     event_id = "event1"
     node_id = "node1"
@@ -37,7 +36,6 @@ def test_apply_create_node_event_success(graph: MockGraph):
 
 
 def test_apply_create_node_event_no_attributes(graph: MockGraph):
-
     """Test successfully creating a new node with no initial attributes."""
     node_id = "node_no_attr"
     event = Event(
@@ -57,14 +55,16 @@ def test_apply_create_node_event_already_exists(graph: PersistentGraph):
     event = Event(
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
-        payload={"node_id": node_id, "attributes": {"name": "New Node", "type": "UserMemory"}},
+        payload={
+            "node_id": node_id,
+            "attributes": {"name": "New Node", "type": "UserMemory"},
+        },
     )
     with pytest.raises(ProcessingError, match=f"Node '{node_id}' already exists"):
         apply_event_to_graph(event, graph)
 
 
 def test_apply_create_node_missing_node_id(graph: MockGraph):
-
     """Test error when 'node_id' is missing in payload for CREATE_NODE."""
     event = Event(
         event_type=EventType.CREATE_NODE,
@@ -78,7 +78,6 @@ def test_apply_create_node_missing_node_id(graph: MockGraph):
 
 
 def test_apply_create_node_invalid_node_id_type(graph: MockGraph):
-
     """Test error when 'node_id' is not a string for CREATE_NODE."""
     event = Event(
         event_type=EventType.CREATE_NODE,
@@ -92,7 +91,6 @@ def test_apply_create_node_invalid_node_id_type(graph: MockGraph):
 
 
 def test_apply_update_node_attributes_success(graph: MockGraph):
-
     """Test successfully updating attributes of an existing node."""
     node_id = "node1"
     initial_attrs = {"name": "Initial Name", "status": "active"}
@@ -110,7 +108,6 @@ def test_apply_update_node_attributes_success(graph: MockGraph):
 
 
 def test_apply_update_node_attributes_node_not_exists(graph: MockGraph):
-
     """Test error when trying to update attributes of a non-existent node."""
     node_id = "node_not_found"
     event = Event(
@@ -125,7 +122,6 @@ def test_apply_update_node_attributes_node_not_exists(graph: MockGraph):
 
 
 def test_apply_update_node_attributes_missing_node_id(graph: MockGraph):
-
     """Test error for UPDATE_NODE_ATTRIBUTES if 'node_id' is missing."""
     event = Event(
         event_type=EventType.UPDATE_NODE_ATTRIBUTES,
@@ -212,7 +208,6 @@ def test_apply_update_node_attributes_invalid_attributes_payload(
 
 
 def test_apply_unknown_event_type(graph: MockGraph):
-
     """Test error when an unknown event_type is encountered."""
     event = Event(
         event_type="UNKNOWN_EVENT_TYPE",
@@ -249,7 +244,6 @@ def test_apply_create_edge_event_success(graph: PersistentGraph):
 
 
 def test_apply_create_edge_event_missing_source_node(graph: MockGraph):
-
     """Test CREATE_EDGE when source node does not exist (error from adapter)."""
     graph.add_node("target_node", {})  # Target exists
     event = Event(
@@ -268,7 +262,6 @@ def test_apply_create_edge_event_missing_source_node(graph: MockGraph):
 
 
 def test_apply_create_edge_event_missing_target_node(graph: MockGraph):
-
     """Test CREATE_EDGE when target node does not exist (error from adapter)."""
     graph.add_node("source_node", {})  # Source exists
     event = Event(
@@ -287,7 +280,6 @@ def test_apply_create_edge_event_missing_target_node(graph: MockGraph):
 
 
 def test_apply_create_edge_event_invalid_field_types_propagates_error(graph: MockGraph):
-
     """
     Test CREATE_EDGE when event fields (node_id, target_node_id, label) are not strings.
     This tests the defensive checks in apply_event_to_graph.
@@ -307,7 +299,6 @@ def test_apply_create_edge_event_invalid_field_types_propagates_error(graph: Moc
     with pytest.raises(
         ProcessingError, match="Invalid event structure for CREATE_EDGE"
     ):
-
         apply_event_to_graph(event_bad_target_type, graph)
 
     # Example: label is int
@@ -346,7 +337,6 @@ def test_apply_delete_edge_event_success(graph: PersistentGraph):
 
 
 def test_apply_delete_edge_event_edge_not_exist(graph: MockGraph):
-
     """Test DELETE_EDGE when the specified edge does not exist (error from adapter)."""
     graph.add_node("s_node", {})
     graph.add_node("t_node", {})
@@ -367,14 +357,12 @@ def test_apply_delete_edge_event_edge_not_exist(graph: MockGraph):
 
 
 def test_apply_delete_edge_event_invalid_field_types_propagates_error(graph: MockGraph):
-
     """
     Test DELETE_EDGE when event fields (node_id, target_node_id, label) are not strings.
     This tests the defensive checks in apply_event_to_graph.
     """
     event_bad_label_type = Event(
-
-      event_type=EventType.DELETE_EDGE,
+        event_type=EventType.DELETE_EDGE,
         timestamp=int(time.time()),
         node_id="s",
         target_node_id="t",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,15 +7,19 @@ class DummySession:
 
     def run(self, query, parameters=None):
         self.last = (query, parameters)
+
         class R:
             def __init__(self):
                 self._data = {"ok": True}
+
             def data(self):
                 return self._data
+
         return [R()]
 
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         pass
 
@@ -23,8 +27,10 @@ class DummySession:
 class DummyDriver:
     def __init__(self):
         self.session_obj = DummySession()
+
     def session(self):
         return self.session_obj
+
     def close(self):
         pass
 

--- a/tests/test_rbac_adapter.py
+++ b/tests/test_rbac_adapter.py
@@ -22,4 +22,3 @@ def test_find_connected_nodes_requires_analytics_agent():
 
     analytics = RoleBasedGraphAdapter(graph, role="AnalyticsAgent")
     assert analytics.find_connected_nodes("n1") == []
-

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -11,11 +11,7 @@ def test_unknown_event_type_raises_validation_error():
     with pytest.raises(ValidationError):
         validate_event_dict(data)
 
+
 def test_validate_create_node_schema_success():
-    data = {
-        "event_type": "CREATE_NODE",
-        "timestamp": 1,
-        "node_id": "n1",
-        "payload": {}
-    }
+    data = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
     validate_event_dict(data)


### PR DESCRIPTION
## Summary
- cache Poetry and pip data in CI
- fix tests by removing custom sys.modules manipulation
- export audit utilities for test imports
- apply Ruff formatting to repo

## Testing
- `poetry run ruff check src tests`
- `poetry run ruff format --check src tests`
- `poetry run pytest --maxfail=1 --disable-warnings -q tests/`
- `./act -n -j test-and-lint` *(fails: prompts for docker image selection)*

------
https://chatgpt.com/codex/tasks/task_e_6849943a14588326b3f0310eaad096b0