### PR TITLE
Handle docstring-only diffs in CI check

### DIFF
--- a/scripts/ci_should_run.py
+++ b/scripts/ci_should_run.py
@@ -42,25 +42,49 @@ def docs_only(files: list[str]) -> bool:
 
 
 def code_diff_present(diff_lines: list[str]) -> bool:
-    """Return True if any added/removed line contains real code."""
+    """Return True if any added/removed line contains real code.
 
+    The function walks through ``diff_lines`` and keeps track of whether the
+    current position is inside a triple-quoted block. All lines within such a
+    block are treated as documentation/comment changes.
+    """
+
+    in_triple = False
     for line in diff_lines:
         if line.startswith("+++ ") or line.startswith("--- "):
             continue
         if line.startswith("@@"):
+            in_triple = False
             continue
-        if line.startswith("+") or line.startswith("-"):
-            content = line[1:].strip()
-            if not content:
+
+        prefix = line[:1]
+        if prefix not in {"+", "-", " "}:
+            continue
+
+        content = line[1:]
+        stripped = content.strip()
+
+        quote_count = stripped.count('"""') + stripped.count("'''")
+        if quote_count:
+            if quote_count % 2 == 1:
+                in_triple = not in_triple
+            cleaned = stripped.replace('"""', "").replace("'''", "").strip()
+            if not cleaned or in_triple:
                 continue
-            if content.startswith("#"):
-                continue
-            if content.startswith("//"):
-                continue
-            stripped = content.lstrip()
-            if stripped.startswith('"""') or stripped.startswith("'''"):
-                continue
-            return True
+
+        if prefix == " ":
+            # Context line outside a quoted block
+            continue
+
+        if in_triple:
+            continue
+        if not stripped:
+            continue
+        if stripped.startswith("#") or stripped.startswith("//"):
+            continue
+
+        return True
+
     return False
 
 
@@ -71,7 +95,7 @@ def main() -> int:
     if docs_only(changed_files):
         return 1
 
-    diff_lines = run(["git", "diff", "-U0", base, "HEAD"])
+    diff_lines = run(["git", "diff", "-U1", base, "HEAD"])
     return 0 if code_diff_present(diff_lines) else 1
 
 

--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -20,3 +20,17 @@ def test_code_diff_present():
 
     diff2 = ["+print('hi')"]
     assert csr.code_diff_present(diff2) is True
+
+
+def test_docstring_edits_do_not_trigger_ci():
+    diff = [
+        "@@ -1,6 +1,6 @@",
+        " def foo():",
+        '-    """Old summary.',
+        "-    Old details.",
+        '-    """',
+        '+    """Old summary.',
+        "+    New details.",
+        '+    """',
+    ]
+    assert csr.code_diff_present(diff) is False


### PR DESCRIPTION
## Summary
- improve `code_diff_present` in the CI utility to track triple quoted blocks
- ignore edits inside docstrings when deciding to run CI
- update diff generation to include context lines
- add regression test for docstring edits

## Testing
- `ruff check scripts/ci_should_run.py tests/test_ci_should_run.py`
- `ruff format --check scripts/ci_should_run.py tests/test_ci_should_run.py`
- `mypy scripts/ci_should_run.py`
- `pytest tests/test_ci_should_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68499cffcc3c83268bc730d4d52b2733