### PR TITLE
Refine docs detection in CI

### DIFF
--- a/scripts/ci_should_run.py
+++ b/scripts/ci_should_run.py
@@ -19,18 +19,14 @@ def run(cmd: list[str]) -> list[str]:
 
 
 def docs_only(files: list[str]) -> bool:
-    """Return True if every file is a documentation file."""
+    """Return True if every file is Markdown, reStructuredText, plaintext, or
+    lives under ``docs/``.
+    """
 
     doc_exts = (
         ".md",
         ".rst",
         ".txt",
-        ".yml",
-        ".yaml",
-        ".json",
-        ".toml",
-        ".ini",
-        ".cfg",
     )
     for path in files:
         if path.startswith("docs/"):

--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -5,9 +5,7 @@ def test_docs_only():
     assert csr.docs_only(["README.md", "docs/intro.rst"]) is True
     assert csr.docs_only(["README.md", "src/foo.py"]) is False
 
-    for ext in (".json", ".toml", ".ini", ".cfg"):
-        fname = f"config{ext}"
-        assert csr.docs_only([fname]) is True
+    assert csr.docs_only(["config.toml"]) is False
 
 
 def test_code_diff_present():

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,9 +1,14 @@
 import json
+import importlib
 
 import pytest
 from presidio_analyzer import RecognizerResult
 
-from ume import privacy_agent
+
+@pytest.fixture
+def privacy_agent():
+    """Return the privacy_agent module for tests."""
+    return importlib.import_module("ume.privacy_agent")
 
 class FakeAnalyzer:
     def __init__(self, results):


### PR DESCRIPTION
## Summary
- update `docs_only` to only treat markdown, RST, TXT, or docs/ files as documentation
- test that `config.toml` is no longer treated as documentation
- add pytest fixture for privacy agent tests

## Testing
- `pre-commit run --files tests/test_privacy_agent.py scripts/ci_should_run.py tests/test_ci_should_run.py`
- `pytest tests/test_ci_should_run.py tests/test_privacy_agent.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499cf6d11c83269b34fdaeea74fb77