### PR TITLE
Add tests for nested strings and code blocks

### DIFF
--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -32,3 +32,35 @@ def test_docstring_edits_do_not_trigger_ci():
         '+    """',
     ]
     assert csr.code_diff_present(diff) is False
+
+
+def test_nested_triple_quoted_strings():
+    diff = [
+        "@@ -1,8 +1,8 @@",
+        " def foo():",
+        '     """Top-level docstring.',
+        '-    """inner"""',
+        '+    """modified"""',
+        '     """',
+    ]
+    assert csr.code_diff_present(diff) is False
+
+
+def test_raw_string_with_triple_quotes():
+    diff = [
+        "@@ -1 +1 @@",
+        '-pattern = r"""foo"""',
+        '+pattern = r"""bar"""',
+    ]
+    assert csr.code_diff_present(diff) is True
+
+
+def test_markdown_code_block_changes_trigger_ci():
+    diff = [
+        "@@ -1,5 +1,5 @@",
+        " ```python",
+        '-print("hello")',
+        '+print("bye")',
+        " ```",
+    ]
+    assert csr.code_diff_present(diff) is True


### PR DESCRIPTION
## Summary
- test nested triple-quoted strings
- test raw strings with triple quotes
- test markdown code blocks in docs

## Testing
- `ruff check tests/test_ci_should_run.py`
- `mypy tests/test_ci_should_run.py`
- `pytest tests/test_ci_should_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a60252788326a2ff95a96366f33d