### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      # use `poetry export` or rely on lockfile


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to enable Dependabot updates for GitHub Actions and Python dependencies managed via Poetry
- fix missing imports in `tests/test_privacy_agent.py`

## Testing
- `pre-commit run --files .github/dependabot.yml tests/test_privacy_agent.py`
- `poetry run pytest tests/test_privacy_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a60205d48326bf3a42817ea51aac