### PR TITLE
Add docs ignore patterns to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   test-and-lint:

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,14 +1,8 @@
 import json
-
 from presidio_analyzer import RecognizerResult
 
 from ume import privacy_agent
 
-
-@pytest.fixture
-def privacy_agent():
-    """Return the privacy_agent module for tests."""
-    return importlib.import_module("ume.privacy_agent")
 
 class FakeAnalyzer:
     def __init__(self, results):


### PR DESCRIPTION
## Summary
- update CI trigger rules to skip when docs or markdown files change
- remove unused fixture in privacy agent tests causing CI failures

## Testing
- `poetry run ruff check src tests`
- `poetry run ruff format --check src tests`
- `poetry run mypy`
- `poetry run pytest --maxfail=1 --disable-warnings -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6849a6011818832691e8da6fc2c593b1