### PR TITLE
Add pre-commit to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: |
           pip install types-PyYAML types-pytz types-requests types-ujson
 
+      - name: Run pre-commit
+        if: steps.changes.outputs.run == 'true'
+        run: pre-commit run --all-files --color always
+
       - name: Run unit tests (pytest)
         if: steps.changes.outputs.run == 'true'
         run: |

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,14 +1,7 @@
 import json
-
 from presidio_analyzer import RecognizerResult
 
 from ume import privacy_agent
-
-
-@pytest.fixture
-def privacy_agent():
-    """Return the privacy_agent module for tests."""
-    return importlib.import_module("ume.privacy_agent")
 
 class FakeAnalyzer:
     def __init__(self, results):


### PR DESCRIPTION
## Summary
- run `pre-commit` in CI before tests and linters
- fix imports in privacy agent tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `poetry run ruff check src tests`
- `poetry run mypy`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a6006b288326a5b1edad9659c746