### PR TITLE
Extend docs detection

### DIFF
--- a/scripts/ci_should_run.py
+++ b/scripts/ci_should_run.py
@@ -27,6 +27,8 @@ def docs_only(files: list[str]) -> bool:
         ".md",
         ".rst",
         ".txt",
+        ".mdx",
+        ".adoc",
     )
     for path in files:
         if path.startswith("docs/"):

--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -3,6 +3,8 @@ import scripts.ci_should_run as csr
 
 def test_docs_only():
     assert csr.docs_only(["README.md", "docs/intro.rst"]) is True
+    assert csr.docs_only(["README.mdx"]) is True
+    assert csr.docs_only(["README.adoc"]) is True
     assert csr.docs_only(["README.md", "src/foo.py"]) is False
 
     assert csr.docs_only(["config.toml"]) is False


### PR DESCRIPTION
## Summary
- treat `.mdx` and `.adoc` files as documentation
- test new docs file types

## Testing
- `ruff check scripts/ci_should_run.py tests/test_ci_should_run.py`
- `mypy scripts/ci_should_run.py tests/test_ci_should_run.py`
- `pytest tests/test_ci_should_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a06aaaf408326a10b69f0aa60bb58