### PR TITLE
Fix CI Poetry cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           path: |
             ~/.cache/pypoetry
             ~/.cache/pip
+            ~/.cache/mypy
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-poetry-
 

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,7 +1,14 @@
 import json
 from presidio_analyzer import RecognizerResult
+import pytest
 
 from ume import privacy_agent as privacy_agent_module
+
+
+@pytest.fixture
+def privacy_agent():
+    """Provide the privacy_agent module as a fixture for tests."""
+    return privacy_agent_module
 
 
 class FakeAnalyzer:


### PR DESCRIPTION
## Summary
- update Poetry cache to include mypy directory
- add fixture for privacy_agent tests

## Testing
- `poetry run ruff check .`
- `poetry run mypy`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a06a9b594832695df1b42baf52279