### PR TITLE
Fix CI lint failures and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ Ensure you have installed the development dependencies:
 ```bash
 poetry install --with dev
 ```
+(This project uses `pre-commit` for linting and type checks. To run the same
+checks as CI, execute:)
+```bash
+pre-commit run --all-files
+```
 (Note: `poetry install` by default installs dev dependencies unless `--no-dev` is specified. However, explicitly mentioning `--with dev` can be clearer for users who might have installed with `--no-dev` previously).
 
 ### Running Tests

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 files = src, tests
+check_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ mypy = "*"
 pytest = "*"
 pytest-cov = "*"
 httpx = "*"
+pre-commit = "*"
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from ume import privacy_agent as privacy_agent_module
 
+
 @pytest.fixture
 def privacy_agent():
     return privacy_agent_module

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -39,7 +39,7 @@ def test_audit_entry_on_policy_violation(tmp_path, monkeypatch):
     entries = get_audit_entries()
     assert len(entries) == start + 1
     assert entries[-1]["user_id"] == "tester"
-    assert "forbidden" in entries[-1]["reason"]
+    assert "forbidden" in str(entries[-1]["reason"])
 
 
 def test_audit_entry_on_redactions(tmp_path, monkeypatch):
@@ -70,8 +70,8 @@ def test_audit_entry_on_redactions(tmp_path, monkeypatch):
 
     entries = get_audit_entries()
     assert len(entries) == start + 2
-    assert entries[-2]["reason"].startswith("redact_node")
-    assert entries[-1]["reason"].startswith("redact_edge")
+    assert str(entries[-2]["reason"]).startswith("redact_node")
+    assert str(entries[-1]["reason"]).startswith("redact_edge")
     assert all(e["user_id"] == "redactor" for e in entries[-2:])
 
 

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -80,7 +80,9 @@ def test_graph_serialization_roundtrip_with_nodes_and_edges():
 
     # Ensure original graph is not affected by modifications to dumped_data (due to .copy())
     dumped_data["nodes"]["a"]["name"] = "Changed Name"
-    assert graph.get_node("a")["name"] == "Alice"
+    node_a = graph.get_node("a")
+    assert node_a is not None
+    assert node_a["name"] == "Alice"
     if dumped_data["edges"]:  # If there are edges
         dumped_data["edges"][0] = (
             "c",

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -69,8 +69,8 @@ def test_add_node_duplicate_raises():
         graph.add_node("dup", {})
 
 
-def test_gds_methods_issue_queries():
-    results = [[], [], [], [], [], [], []]
+def test_gds_methods_issue_queries() -> None:
+    results: list[list] = [[], [], [], [], [], [], []]
     driver = DummyDriver(results)
     graph = Neo4jGraph(
         "bolt://localhost:7687",

--- a/tests/test_stream_processor.py
+++ b/tests/test_stream_processor.py
@@ -11,6 +11,7 @@ def test_stream_routing():
     app = build_app("kafka://dummy")
     agent = next(iter(app.agents.values()))
 
+    assert agent.fun.__closure__ is not None
     edge_topic = agent.fun.__closure__[0].cell_contents
     node_topic = agent.fun.__closure__[1].cell_contents
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -49,10 +49,11 @@ class UMEPrompt(Cmd):
         role = os.environ.get("UME_ROLE")
         if role:
             print(f"INFO: UME-CLI running with role: '{role}'")
-            self.graph: IGraphAdapter = RoleBasedGraphAdapter(base_graph, role)
+            graph: IGraphAdapter = RoleBasedGraphAdapter(base_graph, role)
         else:
             print("INFO: UME-CLI running without a specific role (full permissions).")
-            self.graph: IGraphAdapter = base_graph
+            graph = base_graph
+        self.graph: IGraphAdapter = graph
         if db_path != ":memory:":
             enable_snapshot_autosave_and_restore(
                 base_graph, settings.UME_SNAPSHOT_PATH, 24 * 3600


### PR DESCRIPTION
## Summary
- add `pre-commit` as a development dependency
- document running `pre-commit run --all-files`
- enable `check_untyped_defs` in `mypy.ini`
- fix formatting in tests
- tighten some test type assertions and fix CLI attribute typing

## Testing
- `pre-commit run --all-files`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ad0fdbddc8326a44ab5f5ac752131