### PR TITLE
Add codex setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ pre-commit run --all-files
 ```
 (Note: `poetry install` by default installs dev dependencies unless `--no-dev` is specified. However, explicitly mentioning `--with dev` can be clearer for users who might have installed with `--no-dev` previously).
 
+To determine if your changes require running tests and linters, execute:
+```bash
+python scripts/ci_should_run.py && echo "Run tests" || echo "Docs only, skipping"
+```
+
 ### Running Tests
 
 1.  **Run all tests:**
@@ -253,6 +258,11 @@ git clone https://github.com/d0tTino/universal-memory-engine.git
 cd universal-memory-engine
 poetry install
 poetry run python -m spacy download en_core_web_lg
+```
+To automate the above steps (including installing development tools), you can
+run the helper script:
+```bash
+./codex_setup.sh
 ```
 
 ### 2. Start Redpanda (Kafka) via Docker

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need_pkgs=()
+command -v python3.12 >/dev/null 2>&1 || need_pkgs+=(python3.12 python3.12-venv python3.12-dev)
+command -v gcc >/dev/null 2>&1 || need_pkgs+=(build-essential)
+if [ "${#need_pkgs[@]}" -ne 0 ]; then
+    sudo apt-get update
+    sudo apt-get install -y "${need_pkgs[@]}"
+fi
+
+python3.12 -m pip install --upgrade pip poetry
+poetry install --with dev --no-interaction --no-ansi
+
+# Download SpaCy model if desired
+if poetry run python -m spacy validate en_core_web_lg >/dev/null 2>&1; then
+    : # already installed
+else
+    poetry run python -m spacy download en_core_web_lg || true
+fi
+
+python3.12 -m pip install types-PyYAML types-pytz types-requests types-ujson
+pre-commit install
+
+echo "To check if tests and linters should run for your branch, execute:"
+echo "python scripts/ci_should_run.py && echo 'Run tests' || echo 'Docs only, skipping'"


### PR DESCRIPTION
## Summary
- add a codex_setup.sh helper
- document how to use the helper script in the README
- mention `ci_should_run.py` for determining when to run tests

## Testing
- `poetry install --with dev`
- `poetry run ruff check src tests`
- `poetry run ruff format --check src tests`
- `poetry run mypy`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684aefecabb083268061770ea1d14895