### PR TITLE
Add codex setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ pre-commit run --all-files
 ```
 (Note: `poetry install` by default installs dev dependencies unless `--no-dev` is specified. However, explicitly mentioning `--with dev` can be clearer for users who might have installed with `--no-dev` previously).
 
+To determine if your changes require running tests and linters, execute:
+```bash
+python scripts/ci_should_run.py && echo "Run tests" || echo "Docs only, skipping"
+```
+If the repository does not have an `origin/main` branch, the helper falls back
+to comparing against the previous commit, so it will still return a meaningful
+result.
+
 ### Running Tests
 
 1.  **Run all tests:**
@@ -251,8 +259,20 @@ ID `"forbidden"`. Additional policies can be added by dropping new modules in
 ```bash
 git clone https://github.com/d0tTino/universal-memory-engine.git
 cd universal-memory-engine
-poetry install
+poetry install --with dev
 poetry run python -m spacy download en_core_web_lg
+```
+To automate the above steps (including installing development tools), you can
+run the helper script:
+```bash
+./codex_setup.sh
+```
+This script installs Python 3.12 if missing, installs all dependencies and
+development tools, automatically installs the pre-commit hooks, and fixes the
+lock file if needed. After running it, you can verify the environment with:
+```bash
+pre-commit run --all-files
+PYTHONPATH=src pytest
 ```
 
 ### 2. Start Redpanda (Kafka) via Docker

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need_pkgs=()
+command -v python3.12 >/dev/null 2>&1 || need_pkgs+=(python3.12 python3.12-venv python3.12-dev)
+command -v gcc >/dev/null 2>&1 || need_pkgs+=(build-essential)
+if [ "${#need_pkgs[@]}" -ne 0 ]; then
+    sudo apt-get update
+    sudo apt-get install -y "${need_pkgs[@]}"
+fi
+
+python3.12 -m pip install --upgrade pip poetry
+if ! poetry install --with dev --no-interaction --no-ansi; then
+    # If the lock file is out of sync, regenerate it and retry
+    poetry lock
+    poetry install --with dev --no-interaction --no-ansi
+fi
+
+# Download SpaCy model if desired
+if poetry run python -m spacy validate en_core_web_lg >/dev/null 2>&1; then
+    : # already installed
+else
+    poetry run python -m spacy download en_core_web_lg || true
+fi
+
+python3.12 -m pip install types-PyYAML types-pytz types-requests types-ujson
+poetry run pre-commit install
+
+echo "To check if tests and linters should run for your branch, execute:"
+echo "python scripts/ci_should_run.py && echo 'Run tests' || echo 'Docs only, skipping'"

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -1,5 +1,8 @@
 import pytest
 
+from typing import cast
+
+from neo4j import Driver
 from ume.neo4j_graph import Neo4jGraph
 from ume.processing import ProcessingError
 
@@ -51,7 +54,12 @@ def test_node_and_edge_crud():
         DummyResult({"cnt": 1}),  # delete edge
     ]
     driver = DummyDriver(results)
-    graph = Neo4jGraph("bolt://localhost:7687", "neo4j", "pass", driver=driver)
+    graph = Neo4jGraph(
+        "bolt://localhost:7687",
+        "neo4j",
+        "pass",
+        driver=cast(Driver, driver),
+    )
 
     graph.add_node("n1", {})
     graph.add_node("n2", {})
@@ -63,7 +71,12 @@ def test_node_and_edge_crud():
 
 def test_add_node_duplicate_raises():
     driver = DummyDriver([DummyResult({"cnt": 1})])
-    graph = Neo4jGraph("bolt://localhost:7687", "neo4j", "pass", driver=driver)
+    graph = Neo4jGraph(
+        "bolt://localhost:7687",
+        "neo4j",
+        "pass",
+        driver=cast(Driver, driver),
+    )
 
     with pytest.raises(ProcessingError):
         graph.add_node("dup", {})
@@ -76,7 +89,7 @@ def test_gds_methods_issue_queries() -> None:
         "bolt://localhost:7687",
         "neo4j",
         "pass",
-        driver=driver,
+        driver=cast(Driver, driver),
         use_gds=True,
     )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,6 @@
 from ume.query import Neo4jQueryEngine
+from neo4j import Driver
+from typing import cast
 
 
 class DummySession:
@@ -36,7 +38,8 @@ class DummyDriver:
 
 
 def test_execute_cypher_returns_records():
-    engine = Neo4jQueryEngine(DummyDriver())
+    driver = DummyDriver()
+    engine = Neo4jQueryEngine(cast(Driver, driver))
     result = engine.execute_cypher("MATCH (n) RETURN n")
     assert result == [{"ok": True}]
-    assert engine._driver.session_obj.last == ("MATCH (n) RETURN n", {})
+    assert driver.session_obj.last == ("MATCH (n) RETURN n", {})


### PR DESCRIPTION
## Summary
- improve codex_setup.sh with automatic `poetry lock` retry
- document verification steps in README, including verifying with `pre-commit` and `pytest`
- update tests to satisfy mypy strictness
- clarify Quickstart to install dev dependencies explicitly
- handle missing `origin/main` in `ci_should_run.py` and document fallback

## Testing
- `poetry run ruff check src tests scripts/ci_should_run.py`
- `poetry run ruff format --check src tests scripts/ci_should_run.py`
- `poetry run mypy`
- `PYTHONPATH=src poetry run pytest`
- `python scripts/ci_should_run.py`

------
https://chatgpt.com/codex/tasks/task_e_684aefecabb083268061770ea1d14895