### PR TITLE
Add tests for client and demos

### DIFF
--- a/tests/test_client_module.py
+++ b/tests/test_client_module.py
@@ -1,0 +1,93 @@
+import json
+import pytest
+from jsonschema import ValidationError
+
+from ume.client import UMEClient, UMEClientError
+from ume.event import EventType
+from ume.event import Event
+
+
+class DummyProducer:
+    def __init__(self, conf):
+        self.produced = []
+
+    def produce(self, topic, value):
+        self.produced.append((topic, value))
+
+    def flush(self):
+        pass
+
+
+class DummyConsumer:
+    def __init__(self, conf):
+        self.messages = []
+
+    def subscribe(self, topics):
+        pass
+
+    def poll(self, timeout):
+        return self.messages.pop(0) if self.messages else None
+
+    def close(self):
+        pass
+
+
+class DummySettings:
+    KAFKA_RAW_EVENTS_TOPIC = "raw"
+    KAFKA_CLEAN_EVENTS_TOPIC = "clean"
+    KAFKA_BOOTSTRAP_SERVERS = "server"
+    KAFKA_GROUP_ID = "gid"
+
+
+def build_client(monkeypatch, consumer=None, producer=None):
+    consumer = consumer or DummyConsumer
+    producer = producer or DummyProducer
+    monkeypatch.setattr("ume.client.Consumer", consumer)
+    monkeypatch.setattr("ume.client.Producer", producer)
+    return UMEClient(DummySettings())
+
+
+def test_produce_event(monkeypatch):
+    client = build_client(monkeypatch)
+    event = Event(event_type=EventType.CREATE_NODE.value, timestamp=1, payload={}, node_id="n1", target_node_id="", label="", source="s")
+    client.produce_event(event)
+    produced = client.producer.produced[0]
+    assert produced[0] == "raw"
+    data = json.loads(produced[1].decode("utf-8"))
+    assert data["event_type"] == "CREATE_NODE"
+
+
+def test_produce_event_validation_error(monkeypatch):
+    def bad_validate(_):
+        raise ValidationError("bad")
+
+    monkeypatch.setattr("ume.client.validate_event_dict", bad_validate)
+    client = build_client(monkeypatch)
+    event = Event(event_type=EventType.CREATE_NODE.value, timestamp=1, payload={}, node_id="n1", target_node_id="", label="", source="s")
+    with pytest.raises(UMEClientError):
+        client.produce_event(event)
+
+
+def test_consume_events(monkeypatch):
+    consumer = DummyConsumer({})
+    msg_data = json.dumps({"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}).encode()
+
+    class DummyMsg:
+        def __init__(self, value):
+            self._value = value
+
+        def error(self):
+            return None
+
+        def value(self):
+            return self._value
+
+    consumer.messages.append(DummyMsg(msg_data))
+    client = build_client(monkeypatch, consumer=lambda conf: consumer)
+    events = list(client.consume_events(timeout=0))
+    assert len(events) == 1
+    assert events[0].node_id == "n1"
+    assert events[0].event_type == "CREATE_NODE"
+
+
+

--- a/tests/test_demo_scripts.py
+++ b/tests/test_demo_scripts.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+
+from ume import consumer_demo, producer_demo
+
+
+def test_consumer_ssl_config(monkeypatch):
+    monkeypatch.delenv("KAFKA_CA_CERT", raising=False)
+    monkeypatch.delenv("KAFKA_CLIENT_CERT", raising=False)
+    monkeypatch.delenv("KAFKA_CLIENT_KEY", raising=False)
+    assert consumer_demo.ssl_config() == {}
+
+    monkeypatch.setenv("KAFKA_CA_CERT", "ca")
+    monkeypatch.setenv("KAFKA_CLIENT_CERT", "cert")
+    monkeypatch.setenv("KAFKA_CLIENT_KEY", "key")
+    cfg = consumer_demo.ssl_config()
+    assert cfg["security.protocol"] == "SSL"
+    assert cfg["ssl.ca.location"] == "ca"
+    assert cfg["ssl.certificate.location"] == "cert"
+    assert cfg["ssl.key.location"] == "key"
+
+
+def test_producer_ssl_config(monkeypatch):
+    monkeypatch.delenv("KAFKA_CA_CERT", raising=False)
+    monkeypatch.delenv("KAFKA_CLIENT_CERT", raising=False)
+    monkeypatch.delenv("KAFKA_CLIENT_KEY", raising=False)
+    assert producer_demo.ssl_config() == {}
+
+    monkeypatch.setenv("KAFKA_CA_CERT", "ca")
+    monkeypatch.setenv("KAFKA_CLIENT_CERT", "cert")
+    monkeypatch.setenv("KAFKA_CLIENT_KEY", "key")
+    cfg = producer_demo.ssl_config()
+    assert cfg["security.protocol"] == "SSL"
+    assert cfg["ssl.ca.location"] == "ca"
+    assert cfg["ssl.certificate.location"] == "cert"
+    assert cfg["ssl.key.location"] == "key"
+
+def test_delivery_report():
+    msg = SimpleNamespace(topic=lambda: "t", partition=lambda: 0, offset=lambda: 1)
+    producer_demo.delivery_report(None, msg)
+    producer_demo.delivery_report(Exception("err"), msg)
+

--- a/tests/test_neo4j_gds_flag.py
+++ b/tests/test_neo4j_gds_flag.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ume.neo4j_graph import Neo4jGraph
+
+class DummyDriver:
+    def session(self):
+        class DummySession:
+            def run(self, *a, **k):
+                return []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        return DummySession()
+
+    def close(self):
+        pass
+
+
+def test_gds_requires_flag():
+    graph = Neo4jGraph("bolt://", "u", "p", driver=DummyDriver())
+    with pytest.raises(NotImplementedError):
+        graph.pagerank_centrality()
+
+

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -1,0 +1,26 @@
+import sys
+from unittest.mock import Mock
+from ume import graph_adapter as real_ga
+sys.modules.setdefault("ume._internal.graph_adapter", real_ga)  # noqa: E402
+
+from ume._internal import query_helpers as qh  # noqa: E402
+
+
+def test_wrapper_methods_call_graph():
+    graph = Mock()
+    qh.shortest_path(graph, "a", "b")
+    qh.traverse(graph, "a", 1, edge_label="L")
+    qh.extract_subgraph(graph, "a", 2, edge_label=None, since_timestamp=5)
+    qh.constrained_path(graph, "a", "b", max_depth=3, edge_label="L", since_timestamp=4)
+
+    graph.shortest_path.assert_called_once_with("a", "b")
+    graph.traverse.assert_called_once_with("a", 1, "L")
+    graph.extract_subgraph.assert_called_once_with("a", 2, None, 5)
+    graph.constrained_path.assert_called_once_with(
+        "a",
+        "b",
+        max_depth=3,
+        edge_label="L",
+        since_timestamp=4,
+    )
+


### PR DESCRIPTION
## Summary
- add coverage tests for UMEClient, query helpers, demo scripts and GDS flag
- ensure wrappers hit graph adapter methods

## Testing
- `pre-commit run --files tests/test_client_module.py tests/test_query_helpers.py tests/test_demo_scripts.py tests/test_neo4j_gds_flag.py`
- `pytest -q tests/test_client_module.py tests/test_query_helpers.py tests/test_demo_scripts.py tests/test_neo4j_gds_flag.py`

------
https://chatgpt.com/codex/tasks/task_e_684b4e3319ac83269de2efc3cd0ff681