### PR TITLE
Fix mypy warnings in tests

### DIFF
--- a/tests/test_client_module.py
+++ b/tests/test_client_module.py
@@ -1,8 +1,11 @@
 import json
+from typing import cast
+
 import pytest
 from jsonschema import ValidationError
 
 from ume.client import UMEClient, UMEClientError
+from ume.config import Settings
 from ume.event import EventType
 from ume.event import Event
 
@@ -44,7 +47,7 @@ def build_client(monkeypatch, consumer=None, producer=None):
     producer = producer or DummyProducer
     monkeypatch.setattr("ume.client.Consumer", consumer)
     monkeypatch.setattr("ume.client.Producer", producer)
-    return UMEClient(DummySettings())
+    return UMEClient(cast(Settings, DummySettings()))
 
 
 def test_produce_event(monkeypatch):

--- a/tests/test_neo4j_gds_flag.py
+++ b/tests/test_neo4j_gds_flag.py
@@ -1,5 +1,7 @@
 import pytest
+from typing import cast
 
+from neo4j import Driver
 from ume.neo4j_graph import Neo4jGraph
 
 class DummyDriver:
@@ -21,7 +23,7 @@ class DummyDriver:
 
 
 def test_gds_requires_flag():
-    graph = Neo4jGraph("bolt://", "u", "p", driver=DummyDriver())
+    graph = Neo4jGraph("bolt://", "u", "p", driver=cast(Driver, DummyDriver()))
     with pytest.raises(NotImplementedError):
         graph.pagerank_centrality()
 


### PR DESCRIPTION
## Summary
- cast dummy Settings and Driver to expected types in tests

## Testing
- `ruff check tests/test_client_module.py tests/test_neo4j_gds_flag.py`
- `mypy tests/test_client_module.py tests/test_neo4j_gds_flag.py`
- `PYTHONPATH=src pytest tests/test_client_module.py tests/test_neo4j_gds_flag.py`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_684b5bcdb7ec8326a83e7532e943acb6