### PR TITLE
Fix query_helpers import path

### DIFF
--- a/src/ume/_internal/query_helpers.py
+++ b/src/ume/_internal/query_helpers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from .graph_adapter import IGraphAdapter
+from ..graph_adapter import IGraphAdapter
 
 
 def shortest_path(graph: IGraphAdapter, source: str, target: str) -> List[str]:

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -1,10 +1,11 @@
-import sys
 from unittest.mock import Mock
 from ume import graph_adapter as real_ga
 
-sys.modules.setdefault("ume._internal.graph_adapter", real_ga)  # noqa: E402
-
 from ume._internal import query_helpers as qh  # noqa: E402
+
+
+def test_import_igraphadapter_consistency():
+    assert qh.IGraphAdapter is real_ga.IGraphAdapter
 
 
 def test_wrapper_methods_call_graph():


### PR DESCRIPTION
## Summary
- import IGraphAdapter from parent package instead of nonexistent local file
- update tests for new import path and check class consistency

## Testing
- `pre-commit run --files src/ume/_internal/query_helpers.py tests/test_query_helpers.py`
- `PYTHONPATH=src pytest tests/test_query_helpers.py -q`
- `python -m compileall src/ume/_internal/query_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_684c874af4488326b340b5dfc4225bb7