### PR TITLE
Add coverage tests for API and CLI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+parallel = True
+concurrency = multiprocessing
+
+[html]
+directory = coverage_html

--- a/tests/test_api_redact_endpoints.py
+++ b/tests/test_api_redact_endpoints.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+@pytest.fixture
+def client_and_graph():
+    g = MockGraph()
+    g.add_node("a", {})
+    g.add_node("b", {})
+    g.add_edge("a", "b", "L")
+    configure_graph(g)
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    return TestClient(app), g
+
+
+def test_redact_node_endpoint(client_and_graph):
+    client, g = client_and_graph
+    res = client.post(
+        "/redact/node/a",
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert g.get_node("a") is None
+
+
+def test_redact_edge_endpoint(client_and_graph):
+    client, g = client_and_graph
+    res = client.post(
+        "/redact/edge",
+        json={"source": "a", "target": "b", "label": "L"},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert g.get_all_edges() == []

--- a/tests/test_cli_internal.py
+++ b/tests/test_cli_internal.py
@@ -1,0 +1,35 @@
+from ume_cli import UMEPrompt, _setup_warnings
+
+
+def test_umeprompt_commands(tmp_path):
+    prompt = UMEPrompt()
+    prompt.do_new_node('n1 "{}"')
+    prompt.do_new_node('n2 "{}"')
+    prompt.do_new_edge('n1 n2 L')
+    assert set(prompt.graph.get_all_node_ids()) == {"n1", "n2"}
+    assert ("n1", "n2", "L") in prompt.graph.get_all_edges()
+
+    snap = tmp_path / "snap.json"
+    prompt.do_snapshot_save(str(snap))
+    assert snap.is_file()
+
+    prompt.do_del_edge('n1 n2 L')
+    assert prompt.graph.get_all_edges() == []
+
+    prompt.do_redact_node('n1')
+    assert prompt.graph.get_node('n1') is None
+
+    prompt.do_clear('')
+    assert prompt.graph.get_all_node_ids() == []
+
+    prompt.do_snapshot_load(str(snap))
+    assert set(prompt.graph.get_all_node_ids()) == {"n1", "n2"}
+
+    # exercise query and audit related commands
+    prompt.do_show_nodes("")
+    prompt.do_show_edges("")
+    prompt.do_neighbors("n1")
+    prompt.do_show_audit("")
+
+    _setup_warnings(True, str(tmp_path / "warn.log"))
+    prompt.do_exit("")


### PR DESCRIPTION
## Summary
- test redact endpoints via API
- add direct CLI command tests for coverage
- configure coverage for subprocess

## Testing
- `ruff check tests/test_api_redact_endpoints.py tests/test_cli_internal.py`
- `mypy tests/test_api_redact_endpoints.py tests/test_cli_internal.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c874fbd1c8326b13e782e639092b4