### PR TITLE
Update FastAPI and regen lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3659,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "18bd660ba7a19761c1489ea04ce0c01685eb8608668fdb4810537bfec597beaf"
+content-hash = "792036235aaeb68050d8cb888a4762f0c523f2b8117643c7800ac1bf65d0d1b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.
 neo4j = "*"
 networkx = "*"
-fastapi = "*"
+fastapi = ">=0.110"
 jsonschema = "*"
 faust-streaming = "*"
 pydantic-settings = "^2.9.1"


### PR DESCRIPTION
## Summary
- require `fastapi>=0.110`
- regenerate `poetry.lock` with `poetry update fastapi`

## Testing
- `poetry run pytest`
- `poetry run mypy`

------
https://chatgpt.com/codex/tasks/task_e_684c9486775c8326881c98c912182d75