### PR TITLE
Update README to require Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ This section outlines the necessary tools for developing and running the Univers
 
 ### Core Tools Required:
 
-*   **Python:** Version 3.12 or newer.
+*   **Python:** Version **3.12** is required. Lower versions (for example 3.11)
+    will fail due to `pydantic_settings` and other dependencies.
 *   **Poetry:** For Python dependency management. Installation instructions can be found at [https://python-poetry.org/docs/#installation](https://python-poetry.org/docs/#installation).
 *   **Docker:** Docker Desktop (for Windows/macOS) or Docker Engine + Docker Compose (for Linux) is required to run backend services like Redpanda. Download from [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/).
 
@@ -252,7 +253,8 @@ ID `"forbidden"`. Additional policies can be added by dropping new modules in
 ## Quickstart
 
 ### Prerequisites
-- Python 3.12+
+- Python **3.12** (required; lower versions such as 3.11 will fail due to
+  `pydantic_settings` and other dependencies)
 - Poetry (https://python-poetry.org)
 - Docker & Docker Compose
 

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -15,3 +15,7 @@ UME_API_TOKEN=secret-token
 # Optional role for the CLI (leave unset for full permissions)
 UME_ROLE=view-only
 ```
+
+If your system Python is older than 3.12, consider using
+[pyenv](https://github.com/pyenv/pyenv) or running in a container image that
+provides Python 3.12 to ensure compatibility.


### PR DESCRIPTION
## Summary
- specify Python 3.12 as the minimum supported version in project setup
- warn that older versions fail in the Quickstart prerequisites
- add a note about using pyenv or a container for Python 3.12 in ENV_EXAMPLE

## Testing
- No tests run since only documentation was modified

------
https://chatgpt.com/codex/tasks/task_e_684ca7c8e8408326b852dfbe59228692