### PR TITLE
Configure ruff via pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v0.4.2
     hooks:
       - id: ruff
+        args: ["--config", "pyproject.toml"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ pre-commit = "*"
 produce_demo = "ume.producer_demo:main"
 ume-cli = "ume_cli:main"
 
+[tool.ruff]
+line-length = 88
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure ruff in `pyproject.toml`
- point the pre-commit ruff hook at the `pyproject.toml`

## Testing
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684ca7c6d0988326b28b85ddca99565d