### PR TITLE
Add SQLite indices for PersistentGraph edges

### DIFF
--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -108,3 +108,11 @@ event = Event(
 
 apply_event_to_graph(event, graph, schema_version=schema.version)
 ```
+
+## SQLite indices
+
+The `PersistentGraph` backend uses SQLite for storing nodes and edges.
+During initialization, indices on the `edges` table are created to
+speed up lookups. An index `idx_edges_source` is always created on the
+`source` column and an additional `idx_edges_target` index is created on
+the `target` column.

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -25,6 +25,13 @@ class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
             self.conn.execute(
                 "CREATE TABLE IF NOT EXISTS edges (source TEXT, target TEXT, label TEXT, redacted INTEGER DEFAULT 0, PRIMARY KEY (source, target, label))"
             )
+            # Indexes speed up queries for edges from a given source or target
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_edges_source ON edges (source)"
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_edges_target ON edges (target)"
+            )
 
     def close(self) -> None:
         self.conn.close()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -376,3 +376,17 @@ def test_delete_edge_non_existent_target_node_implicitly_fails(graph: MockGraph)
     expected = re.escape(f"Edge {edge_tuple} does not exist and cannot be deleted.")
     with pytest.raises(ProcessingError, match=expected):
         graph.delete_edge(edge_tuple[0], edge_tuple[1], edge_tuple[2])
+
+
+def test_edges_indices_created(graph: PersistentGraph):
+    """Ensure edges indices exist and queries function correctly."""
+    graph.add_node("s", {})
+    graph.add_node("t", {})
+    graph.add_edge("s", "t", "REL")
+
+    assert graph.find_connected_nodes("s") == ["t"]
+
+    cur = graph.conn.execute("PRAGMA index_list('edges')")
+    names = {row[1] for row in cur.fetchall()}
+    assert "idx_edges_source" in names
+    assert "idx_edges_target" in names


### PR DESCRIPTION
## Summary
- index edges table by source and target in the SQLite graph
- verify index creation with unit test
- document new indices for the persistent backend

## Testing
- `pre-commit run --files src/ume/persistent_graph.py tests/test_graph.py docs/GRAPH_MODEL.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca7c5d23c8326804b995ad7700bb4