### PR TITLE
Clarify Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ This project uses [pytest](https://docs.pytest.org/) for unit and integration te
 
 ### Prerequisites
 
+You must run the tests with **Python 3.12**. Lower versions such as 3.11
+will fail due to `pydantic_settings` and other dependencies.
+
 Ensure you have installed the development dependencies:
 ```bash
 poetry install --with dev

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -16,6 +16,6 @@ UME_API_TOKEN=secret-token
 UME_ROLE=view-only
 ```
 
-If your system Python is older than 3.12, consider using
-[pyenv](https://github.com/pyenv/pyenv) or running in a container image that
-provides Python 3.12 to ensure compatibility.
+UME requires **Python 3.12**. If your system Python is older than 3.12,
+consider using [pyenv](https://github.com/pyenv/pyenv) or running in a
+container image that provides Python 3.12 to ensure compatibility.


### PR DESCRIPTION
## Summary
- note that tests require Python 3.12
- emphasize Python 3.12 in environment example

## Testing
- `pre-commit` *(skipped: docs-only change)*
- `pytest` *(skipped: docs-only change)*

------
https://chatgpt.com/codex/tasks/task_e_684ca9703a1883268a92afb41ad27c04