### PR TITLE
Pin FastAPI version and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ This section outlines the necessary tools for developing and running the Univers
 *   **Poetry:** For Python dependency management. Installation instructions can be found at [https://python-poetry.org/docs/#installation](https://python-poetry.org/docs/#installation).
 *   **Docker:** Docker Desktop (for Windows/macOS) or Docker Engine + Docker Compose (for Linux) is required to run backend services like Redpanda. Download from [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/).
 
+After installing these tools and cloning the repository, install all Python
+dependencies (including development requirements) with:
+
+```bash
+poetry install --with dev
+```
+
 ## Architecture
 
 This section provides a high-level overview of the Universal Memory Engine (UME) demo setup.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3659,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "792036235aaeb68050d8cb888a4762f0c523f2b8117643c7800ac1bf65d0d1b2"
+content-hash = "9884e37967f1c188b5389ac3ddd4f3da7d1371991ca638b982b0dc02ac8a4509"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.
 neo4j = "*"
 networkx = "*"
-fastapi = ">=0.110"
+# FastAPI >=0.110 requires Pydantic v2 which is compatible with
+# pydantic-settings 2.x, so we pin within the current major release.
+fastapi = ">=0.110,<1"
 jsonschema = "*"
 faust-streaming = "*"
 pydantic-settings = "^2.9.1"


### PR DESCRIPTION
## Summary
- pin `fastapi` to `>=0.110,<1` to ensure compatibility
- note in Project Setup to run `poetry install --with dev`
- regenerate poetry.lock to match new requirement

## Testing
- `poetry run pytest -q`
- `poetry run ruff check`


------
https://chatgpt.com/codex/tasks/task_e_684ca7da1ab88326878b136c678d98be