### PR TITLE
Add CRUD routes for nodes and edges

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -95,6 +95,21 @@ class SubgraphRequest(BaseModel):
     since_timestamp: int | None = None
 
 
+class NodeCreateRequest(BaseModel):
+    id: str
+    attributes: Dict[str, Any] | None = None
+
+
+class NodeUpdateRequest(BaseModel):
+    attributes: Dict[str, Any]
+
+
+class EdgeCreateRequest(BaseModel):
+    source: str
+    target: str
+    label: str
+
+
 @app.post("/analytics/shortest_path")
 def api_shortest_path(
     req: ShortestPathRequest,
@@ -158,4 +173,57 @@ def api_redact_edge(
     graph: IGraphAdapter = Depends(get_graph),
 ) -> Dict[str, Any]:
     graph.redact_edge(req.source, req.target, req.label)
+    return {"status": "ok"}
+
+
+@app.post("/nodes")
+def api_create_node(
+    req: NodeCreateRequest,
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    graph.add_node(req.id, req.attributes or {})
+    return {"status": "ok"}
+
+
+@app.patch("/nodes/{node_id}")
+def api_update_node(
+    node_id: str,
+    req: NodeUpdateRequest,
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    graph.update_node(node_id, req.attributes)
+    return {"status": "ok"}
+
+
+@app.delete("/nodes/{node_id}")
+def api_delete_node(
+    node_id: str,
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    graph.redact_node(node_id)
+    return {"status": "ok"}
+
+
+@app.post("/edges")
+def api_create_edge(
+    req: EdgeCreateRequest,
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    graph.add_edge(req.source, req.target, req.label)
+    return {"status": "ok"}
+
+
+@app.delete("/edges/{source}/{target}/{label}")
+def api_delete_edge(
+    source: str,
+    target: str,
+    label: str,
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    graph.delete_edge(source, target, label)
     return {"status": "ok"}

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -1,0 +1,75 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+@pytest.fixture
+def client_and_graph():
+    g = MockGraph()
+    configure_graph(g)
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    return TestClient(app), g
+
+
+def test_create_node_endpoint(client_and_graph):
+    client, g = client_and_graph
+    res = client.post(
+        "/nodes",
+        json={"id": "n1", "attributes": {"x": 1}},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert g.get_node("n1") == {"x": 1}
+
+
+def test_update_node_endpoint(client_and_graph):
+    client, g = client_and_graph
+    g.add_node("u1", {"a": 1})
+    res = client.patch(
+        "/nodes/u1",
+        json={"attributes": {"b": 2}},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert g.get_node("u1") == {"a": 1, "b": 2}
+
+
+def test_delete_node_endpoint(client_and_graph):
+    client, g = client_and_graph
+    g.add_node("d1", {})
+    res = client.delete(
+        "/nodes/d1",
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert g.get_node("d1") is None
+
+
+def test_create_edge_endpoint(client_and_graph):
+    client, g = client_and_graph
+    g.add_node("s1", {})
+    g.add_node("t1", {})
+    res = client.post(
+        "/edges",
+        json={"source": "s1", "target": "t1", "label": "L"},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert ("s1", "t1", "L") in g.get_all_edges()
+
+
+def test_delete_edge_endpoint(client_and_graph):
+    client, g = client_and_graph
+    g.add_node("s2", {})
+    g.add_node("t2", {})
+    g.add_edge("s2", "t2", "L2")
+    res = client.delete(
+        "/edges/s2/t2/L2",
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 200
+    assert ("s2", "t2", "L2") not in g.get_all_edges()
+


### PR DESCRIPTION
## Summary
- expose node/edge management endpoints in `src/ume/api.py`
- create request models for node and edge operations
- add tests for new API routes

## Testing
- `ruff check src/ume/api.py tests/test_api_mutations.py`
- `mypy --config-file mypy.ini`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca7d97bb08326bd3c1f7bf77aba86