### PR TITLE
Centralize SSL config helper

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -23,6 +23,7 @@ from .schema_utils import validate_event_dict
 from .graph_schema import GraphSchema, load_default_schema
 from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
+from .utils import ssl_config
 
 __all__ = [
     "Event",
@@ -52,4 +53,5 @@ __all__ = [
     "Settings",
     "log_audit_entry",
     "get_audit_entries",
+    "ssl_config",
 ]

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -9,8 +9,8 @@ corresponding producer_demo.py script.
 
 import json
 import logging
-import os
 from ume.config import settings
+from ume.utils import ssl_config
 from confluent_kafka import Consumer, KafkaException, KafkaError  # type: ignore
 from ume import parse_event, EventError  # Import parse_event and EventError
 
@@ -23,21 +23,6 @@ logger = logging.getLogger("consumer_demo")
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 GROUP_ID = settings.KAFKA_GROUP_ID
-
-
-def ssl_config() -> dict:
-    """Return Kafka SSL configuration if cert env vars are set."""
-    ca = os.environ.get("KAFKA_CA_CERT")
-    cert = os.environ.get("KAFKA_CLIENT_CERT")
-    key = os.environ.get("KAFKA_CLIENT_KEY")
-    if ca and cert and key:
-        return {
-            "security.protocol": "SSL",
-            "ssl.ca.location": ca,
-            "ssl.certificate.location": cert,
-            "ssl.key.location": key,
-        }
-    return {}
 
 
 def main():

--- a/src/ume/privacy_agent.py
+++ b/src/ume/privacy_agent.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Dict, Tuple
+from .utils import ssl_config
 
 from confluent_kafka import Consumer, Producer, KafkaException, KafkaError  # type: ignore
 from presidio_analyzer import AnalyzerEngine  # type: ignore
@@ -31,21 +31,6 @@ BATCH_SIZE = settings.KAFKA_PRODUCER_BATCH_SIZE
 # Initialize Presidio engines
 _ANALYZER = AnalyzerEngine()
 _ANONYMIZER = AnonymizerEngine()
-
-
-def ssl_config() -> Dict[str, str]:
-    """Return Kafka SSL configuration if cert env vars are set."""
-    ca = os.environ.get("KAFKA_CA_CERT")
-    cert = os.environ.get("KAFKA_CLIENT_CERT")
-    key = os.environ.get("KAFKA_CLIENT_KEY")
-    if ca and cert and key:
-        return {
-            "security.protocol": "SSL",
-            "ssl.ca.location": ca,
-            "ssl.certificate.location": cert,
-            "ssl.key.location": key,
-        }
-    return {}
 
 
 def redact_event_payload(

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -8,7 +8,7 @@ It's intended to be used with the corresponding consumer_demo.py script.
 
 import json
 import logging
-import os
+from ume.utils import ssl_config
 from ume.config import settings
 import time
 from confluent_kafka import Producer, KafkaException  # type: ignore
@@ -24,21 +24,6 @@ logger = logging.getLogger("producer_demo")
 # Set KAFKA_CA_CERT, KAFKA_CLIENT_CERT and KAFKA_CLIENT_KEY to enable TLS.
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 TOPIC = settings.KAFKA_RAW_EVENTS_TOPIC
-
-
-def ssl_config() -> dict:
-    """Return Kafka SSL configuration if cert env vars are set."""
-    ca = os.environ.get("KAFKA_CA_CERT")
-    cert = os.environ.get("KAFKA_CLIENT_CERT")
-    key = os.environ.get("KAFKA_CLIENT_KEY")
-    if ca and cert and key:
-        return {
-            "security.protocol": "SSL",
-            "ssl.ca.location": ca,
-            "ssl.certificate.location": cert,
-            "ssl.key.location": key,
-        }
-    return {}
 
 
 def delivery_report(err, msg):

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -1,0 +1,17 @@
+from typing import Dict
+import os
+
+
+def ssl_config() -> Dict[str, str]:
+    """Return Kafka SSL configuration if cert env vars are set."""
+    ca = os.environ.get("KAFKA_CA_CERT")
+    cert = os.environ.get("KAFKA_CLIENT_CERT")
+    key = os.environ.get("KAFKA_CLIENT_KEY")
+    if ca and cert and key:
+        return {
+            "security.protocol": "SSL",
+            "ssl.ca.location": ca,
+            "ssl.certificate.location": cert,
+            "ssl.key.location": key,
+        }
+    return {}

--- a/tests/test_demo_scripts.py
+++ b/tests/test_demo_scripts.py
@@ -1,19 +1,20 @@
 from types import SimpleNamespace
 
 
-from ume import consumer_demo, producer_demo
+from ume import producer_demo
+from ume.utils import ssl_config
 
 
 def test_consumer_ssl_config(monkeypatch):
     monkeypatch.delenv("KAFKA_CA_CERT", raising=False)
     monkeypatch.delenv("KAFKA_CLIENT_CERT", raising=False)
     monkeypatch.delenv("KAFKA_CLIENT_KEY", raising=False)
-    assert consumer_demo.ssl_config() == {}
+    assert ssl_config() == {}
 
     monkeypatch.setenv("KAFKA_CA_CERT", "ca")
     monkeypatch.setenv("KAFKA_CLIENT_CERT", "cert")
     monkeypatch.setenv("KAFKA_CLIENT_KEY", "key")
-    cfg = consumer_demo.ssl_config()
+    cfg = ssl_config()
     assert cfg["security.protocol"] == "SSL"
     assert cfg["ssl.ca.location"] == "ca"
     assert cfg["ssl.certificate.location"] == "cert"
@@ -24,12 +25,12 @@ def test_producer_ssl_config(monkeypatch):
     monkeypatch.delenv("KAFKA_CA_CERT", raising=False)
     monkeypatch.delenv("KAFKA_CLIENT_CERT", raising=False)
     monkeypatch.delenv("KAFKA_CLIENT_KEY", raising=False)
-    assert producer_demo.ssl_config() == {}
+    assert ssl_config() == {}
 
     monkeypatch.setenv("KAFKA_CA_CERT", "ca")
     monkeypatch.setenv("KAFKA_CLIENT_CERT", "cert")
     monkeypatch.setenv("KAFKA_CLIENT_KEY", "key")
-    cfg = producer_demo.ssl_config()
+    cfg = ssl_config()
     assert cfg["security.protocol"] == "SSL"
     assert cfg["ssl.ca.location"] == "ca"
     assert cfg["ssl.certificate.location"] == "cert"


### PR DESCRIPTION
## Summary
- add `ssl_config` helper in `ume.utils`
- refactor producer_demo, consumer_demo, and privacy_agent to use helper
- expose `ssl_config` in `ume.__init__`
- update demo tests for new location

## Testing
- `pre-commit run --files src/ume/utils.py src/ume/producer_demo.py src/ume/consumer_demo.py src/ume/privacy_agent.py src/ume/__init__.py tests/test_demo_scripts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca7d81ea48326bc791709905e0639