### PR TITLE
Add poetry export plugin config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4515,4 +4515,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "9e790ddf7e3a42d994355e1a0df06a73f2be162a74de726e8206dcdee3b4c4c7"
+content-hash = "3cba0450d01de18cd3898114c87bd3aa1062744e0e06b2a3cf473a5fa6ae5c62"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pytest = "*"
 pytest-cov = "*"
 httpx = "*"
 pre-commit = "*"
-poetry-plugin-export = "*"
+poetry-plugin-export = "^1.9.0"
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -72,4 +72,3 @@ def test_delete_edge_endpoint(client_and_graph):
     )
     assert res.status_code == 200
     assert ("s2", "t2", "L2") not in g.get_all_edges()
-

--- a/tests/test_api_rbac.py
+++ b/tests/test_api_rbac.py
@@ -141,4 +141,3 @@ def test_redact_edge_forbidden_with_role_based_adapter():
         headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
     )
     assert res.status_code == 403
-

--- a/tests/test_api_redact_endpoints.py
+++ b/tests/test_api_redact_endpoints.py
@@ -5,6 +5,7 @@ from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 
+
 @pytest.fixture
 def client_and_graph():
     g = MockGraph()

--- a/tests/test_cli_internal.py
+++ b/tests/test_cli_internal.py
@@ -5,7 +5,7 @@ def test_umeprompt_commands(tmp_path):
     prompt = UMEPrompt()
     prompt.do_new_node('n1 "{}"')
     prompt.do_new_node('n2 "{}"')
-    prompt.do_new_edge('n1 n2 L')
+    prompt.do_new_edge("n1 n2 L")
     assert set(prompt.graph.get_all_node_ids()) == {"n1", "n2"}
     assert ("n1", "n2", "L") in prompt.graph.get_all_edges()
 
@@ -13,13 +13,13 @@ def test_umeprompt_commands(tmp_path):
     prompt.do_snapshot_save(str(snap))
     assert snap.is_file()
 
-    prompt.do_del_edge('n1 n2 L')
+    prompt.do_del_edge("n1 n2 L")
     assert prompt.graph.get_all_edges() == []
 
-    prompt.do_redact_node('n1')
-    assert prompt.graph.get_node('n1') is None
+    prompt.do_redact_node("n1")
+    assert prompt.graph.get_node("n1") is None
 
-    prompt.do_clear('')
+    prompt.do_clear("")
     assert prompt.graph.get_all_node_ids() == []
 
     prompt.do_snapshot_load(str(snap))

--- a/tests/test_neo4j_gds_flag.py
+++ b/tests/test_neo4j_gds_flag.py
@@ -5,6 +5,7 @@ from typing import cast
 from neo4j import Driver
 from ume.neo4j_graph import Neo4jGraph
 
+
 class DummyDriver:
     def session(self):
         class DummySession:

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -21,7 +21,9 @@ class FakeAnalyzer:
 
 class FakeAnonymizer:
     def anonymize(self, text: str, analyzer_results):
-        return type("Result", (), {"text": text.replace("user@example.com", "<EMAIL_ADDRESS>")})()
+        return type(
+            "Result", (), {"text": text.replace("user@example.com", "<EMAIL_ADDRESS>")}
+        )()
 
 
 def test_redact_event_payload_with_pii(privacy_agent, monkeypatch):
@@ -191,9 +193,13 @@ def test_privacy_agent_audit_log_written(tmp_path, monkeypatch):
     quarantine_topic = privacy_agent.QUARANTINE_TOPIC
 
     clean_msg = next(val for (topic, val) in producer.produced if topic == clean_topic)
-    quarantine_msg = next(val for (topic, val) in producer.produced if topic == quarantine_topic)
+    quarantine_msg = next(
+        val for (topic, val) in producer.produced if topic == quarantine_topic
+    )
 
-    assert json.loads(clean_msg.decode("utf-8"))["payload"] == {"email": "<EMAIL_ADDRESS>"}
+    assert json.loads(clean_msg.decode("utf-8"))["payload"] == {
+        "email": "<EMAIL_ADDRESS>"
+    }
     assert json.loads(quarantine_msg.decode("utf-8")) == {"original": payload}
 
     entries = audit.get_audit_entries()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -278,7 +278,9 @@ def test_apply_create_edge_event_missing_target_node(graph: PersistentGraph):
         apply_event_to_graph(event, graph)
 
 
-def test_apply_create_edge_event_invalid_field_types_propagates_error(graph: PersistentGraph):
+def test_apply_create_edge_event_invalid_field_types_propagates_error(
+    graph: PersistentGraph,
+):
     """
     Test CREATE_EDGE when event fields (node_id, target_node_id, label) are not strings.
     This tests the defensive checks in apply_event_to_graph.
@@ -355,7 +357,9 @@ def test_apply_delete_edge_event_edge_not_exist(graph: PersistentGraph):
         apply_event_to_graph(event, graph)
 
 
-def test_apply_delete_edge_event_invalid_field_types_propagates_error(graph: PersistentGraph):
+def test_apply_delete_edge_event_invalid_field_types_propagates_error(
+    graph: PersistentGraph,
+):
     """
     Test DELETE_EDGE when event fields (node_id, target_node_id, label) are not strings.
     This tests the defensive checks in apply_event_to_graph.


### PR DESCRIPTION
## Summary
- pin `poetry-plugin-export` in the dev group
- ensure CI installs the export plugin before generating requirements
- run `ruff format` on the repository

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml pyproject.toml`
- `poetry run pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`
- `poetry export -f requirements.txt --without-hashes | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684caf72f4048326b440e07c87bd1ef2