### PR TITLE
Add architecture overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,19 @@ Used to remove a specific directed, labeled edge between two nodes.
 *   `label`: String, label of the edge.
 **Optional Fields:** `event_id`, `source`, `payload`.
 
-**Event Flow:**
+**Event Flow:** *(see the full diagram in [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md))*
 
 ```
 Producer --> ume-raw-events --> Privacy Agent --> ume-clean-events
-     --> Graph Consumer --> Graph Adapter --> Storage (SQLite/Neo4j)
+     --> Graph Consumer --> Graph Adapter --> Storage (SQLite/Neo4j) & Vector Store
 ```
 
 1. `producer_demo.py` publishes raw events to the `ume-raw-events` Kafka topic.
 2. The **Privacy Agent** consumes these events, redacts PII, and forwards sanitized messages to `ume-clean-events`.
 3. A graph consumer reads sanitized events and applies them via the configured **Graph Adapter**.
-4. The adapter persists nodes and edges to the chosen backend, such as SQLite or Neo4j.
+4. The adapter persists nodes and edges to the chosen backend, such as SQLite or Neo4j, and writes embeddings to a vector store.
+
+When nodes include textual attributes, the consumer generates vector embeddings using the configured model. These embeddings are stored in the vector store and queried via similarity search to locate relevant nodes before running graph traversals.
 
 This pipeline demonstrates how UME transforms incoming events into a persistent knowledge graph.
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,22 @@
+# Architecture Overview
+
+This diagram illustrates how events flow through UME and how graph data and vector embeddings are stored.
+
+```mermaid
+graph TD
+    Producer(Event Producer) --> RawEvents[ume-raw-events]
+    RawEvents --> PrivacyAgent(Privacy Agent)
+    PrivacyAgent --> CleanEvents[ume-clean-events]
+    CleanEvents --> GraphConsumer(Graph Consumer)
+    GraphConsumer --> Adapter(Graph Adapter)
+    Adapter --> GraphDB[(Graph Storage)]
+    Adapter --> VectorStore[(Vector Store)]
+```
+
+Events originate from producers and are first written to the `ume-raw-events` topic. The Privacy Agent sanitizes sensitive
+content before forwarding messages to `ume-clean-events`. A graph consumer processes these events through the configured
+Graph Adapter. The adapter persists the knowledge graph to the chosen backend (SQLite, Neo4j, etc.) and stores
+embeddings in a dedicated vector store.
+
+When querying, the API can perform a similarity search against the vector store to retrieve relevant nodes and
+then issue graph queries to traverse relationships.


### PR DESCRIPTION
## Summary
- add `docs/ARCHITECTURE_OVERVIEW.md` describing event flow, graph storage and vector store
- reference this doc from the README architecture section and explain embeddings

## Testing
- `pre-commit` *(skipped: documentation only)*
- `pytest` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_684f37e902b483269e5eb46e9446648b