### PR TITLE
Add FAISS vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,24 @@ score = graph_similarity(g1, g2)
 print(score)
 ```
 
+## Vector Store
+
+UME can optionally maintain a FAISS index of node embeddings. When a
+`CREATE_NODE` or `UPDATE_NODE_ATTRIBUTES` event contains an `embedding` field
+in its attributes, the vector is added to the index via
+`VectorStoreListener`.
+
+Set the following environment variables to configure the store:
+
+- `UME_VECTOR_DIM` – dimension of the embedding vectors (default `1536`).
+- `UME_VECTOR_INDEX` – path of the FAISS index file.
+
+Install the optional dependencies with:
+
+```bash
+poetry install --with vector
+```
+
 ## Where to Get Help
 
 If you have questions, encounter issues, or want to discuss ideas related to UME, please feel free to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ httpx = "*"
 pre-commit = "*"
 poetry-plugin-export = "^1.9.0"
 
+[tool.poetry.extras]
+vector = ["faiss-gpu"]
+
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"
 ume-cli = "ume_cli:main"

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -24,6 +24,7 @@ from .graph_schema import GraphSchema, load_default_schema
 from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
 from .utils import ssl_config
+from .vector_store import VectorStore, VectorStoreListener
 
 __all__ = [
     "Event",
@@ -54,4 +55,6 @@ __all__ = [
     "log_audit_entry",
     "get_audit_entries",
     "ssl_config",
+    "VectorStore",
+    "VectorStoreListener",
 ]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -14,6 +14,10 @@ class Settings(BaseSettings):
     UME_AUDIT_SIGNING_KEY: str = "default-key"
     UME_AGENT_ID: str = "SYSTEM"
 
+    # Vector store
+    UME_VECTOR_DIM: int = 1536
+    UME_VECTOR_INDEX: str = "vectors.faiss"
+
     # Kafka/Redpanda
     KAFKA_BOOTSTRAP_SERVERS: str = "localhost:9092"
     KAFKA_RAW_EVENTS_TOPIC: str = "ume-raw-events"

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import numpy as np
+import faiss
+
+from ._internal.listeners import GraphListener
+
+
+class VectorStore:
+    """Simple FAISS-based vector store."""
+
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+        self.index = faiss.IndexFlatL2(dim)
+        self.id_to_idx: Dict[str, int] = {}
+        self.idx_to_id: List[str] = []
+
+    def add(self, item_id: str, vector: List[float]) -> None:
+        arr = np.asarray(vector, dtype="float32").reshape(1, -1)
+        if arr.shape[1] != self.dim:
+            raise ValueError(f"Expected vector of dimension {self.dim}, got {arr.shape[1]}")
+        self.index.add(arr)
+        self.id_to_idx[item_id] = len(self.idx_to_id)
+        self.idx_to_id.append(item_id)
+
+    def query(self, vector: List[float], k: int = 5) -> List[str]:
+        if not self.idx_to_id:
+            return []
+        arr = np.asarray(vector, dtype="float32").reshape(1, -1)
+        if arr.shape[1] != self.dim:
+            raise ValueError(f"Expected vector of dimension {self.dim}, got {arr.shape[1]}")
+        _, indices = self.index.search(arr, min(k, len(self.idx_to_id)))
+        return [self.idx_to_id[i] for i in indices[0] if i != -1]
+
+
+class VectorStoreListener(GraphListener):
+    """GraphListener that indexes embeddings from node attributes."""
+
+    def __init__(self, store: VectorStore) -> None:
+        self.store = store
+
+    def on_node_created(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        emb = attributes.get("embedding")
+        if isinstance(emb, list):
+            self.store.add(node_id, emb)
+
+    def on_node_updated(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        emb = attributes.get("embedding")
+        if isinstance(emb, list):
+            self.store.add(node_id, emb)
+
+    def on_edge_created(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        pass
+
+    def on_edge_deleted(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        pass

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,28 @@
+import time
+from ume import Event, EventType, MockGraph, apply_event_to_graph
+from ume.vector_store import VectorStore, VectorStoreListener
+from ume._internal.listeners import register_listener, unregister_listener
+
+
+def test_vector_store_add_and_query() -> None:
+    store = VectorStore(dim=2)
+    store.add("a", [1.0, 0.0])
+    store.add("b", [0.0, 1.0])
+    res = store.query([1.0, 0.0], k=1)
+    assert res == ["a"]
+
+
+def test_vector_store_listener_on_create() -> None:
+    store = VectorStore(dim=2)
+    listener = VectorStoreListener(store)
+    register_listener(listener)
+    graph = MockGraph()
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "n1", "attributes": {"embedding": [1.0, 0.0]}},
+    )
+    apply_event_to_graph(event, graph)
+    unregister_listener(listener)
+
+    assert store.query([1.0, 0.0], k=1) == ["n1"]


### PR DESCRIPTION
## Summary
- implement `VectorStore` with FAISS and integrate via `VectorStoreListener`
- expose new classes from `ume.__init__`
- add optional `faiss-gpu` extra dependency
- document vector store usage and configuration
- test vector store functionality

## Testing
- `ruff check`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f37eb8ae08326bdc3d9baf688a6c7