### PR TITLE
Unify traversal helpers

### DIFF
--- a/src/ume/_internal/query_helpers.py
+++ b/src/ume/_internal/query_helpers.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from ..graph_adapter import IGraphAdapter
+from ..graph_algorithms import (
+    shortest_path as _shortest_path,
+    traverse as _traverse,
+    extract_subgraph as _extract_subgraph,
+)
 
 
 def shortest_path(graph: IGraphAdapter, source: str, target: str) -> List[str]:
-    """Wrapper around :meth:`IGraphAdapter.shortest_path`."""
-    return graph.shortest_path(source, target)
+    """Return the shortest path between two nodes."""
+    return _shortest_path(graph, source, target)
 
 
 def traverse(
@@ -16,8 +21,8 @@ def traverse(
     depth: int,
     edge_label: Optional[str] = None,
 ) -> List[str]:
-    """Wrapper around :meth:`IGraphAdapter.traverse`."""
-    return graph.traverse(start_node_id, depth, edge_label)
+    """Traverse outward from ``start_node_id`` using the shared algorithm."""
+    return _traverse(graph, start_node_id, depth, edge_label)
 
 
 def extract_subgraph(
@@ -27,8 +32,8 @@ def extract_subgraph(
     edge_label: Optional[str] = None,
     since_timestamp: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Wrapper around :meth:`IGraphAdapter.extract_subgraph`."""
-    return graph.extract_subgraph(start_node_id, depth, edge_label, since_timestamp)
+    """Extract a subgraph using the shared algorithm."""
+    return _extract_subgraph(graph, start_node_id, depth, edge_label, since_timestamp)
 
 
 def constrained_path(

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -10,6 +10,7 @@ import networkx as nx
 import numpy as np
 
 from .graph_adapter import IGraphAdapter
+from .graph_algorithms import shortest_path
 
 
 def _to_networkx(graph: IGraphAdapter) -> nx.DiGraph:
@@ -52,37 +53,6 @@ def _pagerank_numpy(
         if err < n * tol:
             return {nodes[i]: float(x[i]) for i in range(n)}
     raise nx.PowerIterationFailedConvergence(max_iter)
-
-
-def shortest_path(graph: IGraphAdapter, src: str, dst: str) -> List[str]:
-    """Return the shortest directed path from ``src`` to ``dst``.
-
-    This implementation relies on ``graph.find_connected_nodes`` so role-based
-    access checks are enforced by :class:`~ume.rbac_adapter.RoleBasedGraphAdapter`.
-    If no path exists an empty list is returned.
-    """
-    visited: Dict[str, str | None] = {src: None}
-    queue: deque[str] = deque([src])
-    while queue:
-        current = queue.popleft()
-        if current == dst:
-            break
-        for neighbor in graph.find_connected_nodes(current):
-            if neighbor not in visited:
-                visited[neighbor] = current
-                queue.append(neighbor)
-
-    if dst not in visited:
-        return []
-
-    path = [dst]
-    while visited[path[-1]] is not None:
-        prev = visited[path[-1]]
-        assert prev is not None
-        path.append(prev)
-    path.reverse()
-    return path
-
 
 def find_communities(graph: IGraphAdapter) -> List[Set[str]]:
     """Detect communities in the graph."""

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -1,8 +1,96 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .processing import ProcessingError
+from .graph_adapter import IGraphAdapter
+
+
+def shortest_path(graph: IGraphAdapter, source_id: str, target_id: str) -> List[str]:
+    """Return the shortest path from ``source_id`` to ``target_id``."""
+    if not graph.node_exists(source_id) or not graph.node_exists(target_id):
+        return []
+    visited: Dict[str, Optional[str]] = {source_id: None}
+    queue: List[str] = [source_id]
+    while queue:
+        current = queue.pop(0)
+        if current == target_id:
+            break
+        for neighbor in graph.find_connected_nodes(current):
+            if neighbor not in visited:
+                visited[neighbor] = current
+                queue.append(neighbor)
+    if target_id not in visited:
+        return []
+    path = [target_id]
+    while visited[path[-1]] is not None:
+        prev = visited[path[-1]]
+        assert prev is not None
+        path.append(prev)
+    path.reverse()
+    return path
+
+
+def traverse(
+    graph: IGraphAdapter,
+    start_node_id: str,
+    depth: int,
+    edge_label: Optional[str] = None,
+) -> List[str]:
+    """Breadth-first traversal from ``start_node_id`` up to ``depth`` hops."""
+    if not graph.node_exists(start_node_id):
+        raise ProcessingError(f"Node '{start_node_id}' not found.")
+    visited: set[str] = {start_node_id}
+    queue: List[tuple[str, int]] = [(start_node_id, 0)]
+    result: List[str] = []
+    while queue:
+        node, d = queue.pop(0)
+        if d >= depth:
+            continue
+        for neighbor in graph.find_connected_nodes(node, edge_label):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                result.append(neighbor)
+                queue.append((neighbor, d + 1))
+    return result
+
+
+def extract_subgraph(
+    graph: IGraphAdapter,
+    start_node_id: str,
+    depth: int,
+    edge_label: Optional[str] = None,
+    since_timestamp: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a dictionary describing a subgraph rooted at ``start_node_id``."""
+    nodes: Dict[str, Dict[str, Any]] = {}
+    edges: List[Tuple[str, str, str]] = []
+    adj: Dict[str, List[Tuple[str, str]]] = {}
+    for src, tgt, lbl in graph.get_all_edges():
+        adj.setdefault(src, []).append((tgt, lbl))
+
+    to_visit = [(start_node_id, 0)]
+    visited: set[str] = set()
+    while to_visit:
+        node, d = to_visit.pop(0)
+        if node in visited or d > depth:
+            continue
+        visited.add(node)
+        data = graph.get_node(node) or {}
+        include = True
+        if since_timestamp is not None:
+            ts = data.get("timestamp")
+            if ts is None or int(ts) < since_timestamp:
+                include = False
+        if include:
+            nodes[node] = data.copy()
+        if d == depth:
+            continue
+        for tgt, lbl in adj.get(node, []):
+            if edge_label is None or lbl == edge_label:
+                edges.append((node, tgt, lbl))
+                to_visit.append((tgt, d + 1))
+    return {"nodes": nodes, "edges": edges}
 
 
 class GraphAlgorithmsMixin:
@@ -24,27 +112,7 @@ class GraphAlgorithmsMixin:
         raise NotImplementedError
 
     def shortest_path(self, source_id: str, target_id: str) -> List[str]:
-        if not self.node_exists(source_id) or not self.node_exists(target_id):
-            return []
-        visited: Dict[str, Optional[str]] = {source_id: None}
-        queue: List[str] = [source_id]
-        while queue:
-            current = queue.pop(0)
-            if current == target_id:
-                break
-            for neighbor in self.find_connected_nodes(current):
-                if neighbor not in visited:
-                    visited[neighbor] = current
-                    queue.append(neighbor)
-        if target_id not in visited:
-            return []
-        path = [target_id]
-        while visited[path[-1]] is not None:
-            prev = visited[path[-1]]
-            assert prev is not None
-            path.append(prev)
-        path.reverse()
-        return path
+        return shortest_path(cast(IGraphAdapter, self), source_id, target_id)
 
     def traverse(
         self,
@@ -52,21 +120,7 @@ class GraphAlgorithmsMixin:
         depth: int,
         edge_label: Optional[str] = None,
     ) -> List[str]:
-        if not self.node_exists(start_node_id):
-            raise ProcessingError(f"Node '{start_node_id}' not found.")
-        visited: set[str] = {start_node_id}
-        queue: List[tuple[str, int]] = [(start_node_id, 0)]
-        result: List[str] = []
-        while queue:
-            node, d = queue.pop(0)
-            if d >= depth:
-                continue
-            for neighbor in self.find_connected_nodes(node, edge_label):
-                if neighbor not in visited:
-                    visited.add(neighbor)
-                    result.append(neighbor)
-                    queue.append((neighbor, d + 1))
-        return result
+        return traverse(cast(IGraphAdapter, self), start_node_id, depth, edge_label)
 
     def extract_subgraph(
         self,
@@ -75,34 +129,9 @@ class GraphAlgorithmsMixin:
         edge_label: Optional[str] = None,
         since_timestamp: Optional[int] = None,
     ) -> Dict[str, Any]:
-        nodes: Dict[str, Dict[str, Any]] = {}
-        edges: List[Tuple[str, str, str]] = []
-        adj: Dict[str, List[Tuple[str, str]]] = {}
-        for src, tgt, lbl in self.get_all_edges():
-            adj.setdefault(src, []).append((tgt, lbl))
-
-        to_visit = [(start_node_id, 0)]
-        visited: set[str] = set()
-        while to_visit:
-            node, d = to_visit.pop(0)
-            if node in visited or d > depth:
-                continue
-            visited.add(node)
-            data = self.get_node(node) or {}
-            include = True
-            if since_timestamp is not None:
-                ts = data.get("timestamp")
-                if ts is None or int(ts) < since_timestamp:
-                    include = False
-            if include:
-                nodes[node] = data.copy()
-            if d == depth:
-                continue
-            for tgt, lbl in adj.get(node, []):
-                if edge_label is None or lbl == edge_label:
-                    edges.append((node, tgt, lbl))
-                    to_visit.append((tgt, d + 1))
-        return {"nodes": nodes, "edges": edges}
+        return extract_subgraph(
+            cast(IGraphAdapter, self), start_node_id, depth, edge_label, since_timestamp
+        )
 
     def constrained_path(
         self,


### PR DESCRIPTION
## Summary
- define shared shortest_path, traverse and extract_subgraph functions
- re-export shortest_path in analytics
- use the shared functions inside GraphAlgorithmsMixin
- update internal query helpers to reference unified algorithms
- adjust query helper tests

## Testing
- `ruff check src/ume/graph_algorithms.py src/ume/analytics.py src/ume/_internal/query_helpers.py tests/test_query_helpers.py`
- `mypy src/ume/graph_algorithms.py src/ume/analytics.py src/ume/_internal/query_helpers.py tests/test_query_helpers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f37ea8b908326a3f1ef547edf7faf