### PR TITLE
Add embedding generation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,17 @@ score = graph_similarity(g1, g2)
 print(score)
 ```
 
+## Embedding Model
+
+Text attributes can be converted to vector embeddings using a Sentence
+Transformers model. Set `UME_EMBED_MODEL` to the desired Hugging Face
+model name (defaults to `all-MiniLM-L6-v2`). Install the optional
+dependencies with:
+
+```bash
+poetry install --with embedding
+```
+
 ## Vector Store
 
 UME can optionally maintain a FAISS index of node embeddings. When a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pydantic-settings = "^2.9.1"
 presidio-analyzer = "^2.2.358"
 presidio-anonymizer = "^2.2.358"
 spacy = "^3.8.7"
+sentence-transformers = "*"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -35,6 +36,7 @@ poetry-plugin-export = "^1.9.0"
 
 [tool.poetry.extras]
 vector = ["faiss-gpu"]
+embedding = ["sentence-transformers"]
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -26,6 +26,12 @@ from .config import Settings
 from .utils import ssl_config
 from .vector_store import VectorStore, VectorStoreListener
 
+try:  # Optional dependency
+    from .embedding import generate_embedding
+except Exception:  # pragma: no cover - optional import
+    def generate_embedding(text: str) -> list[float]:
+        raise ImportError("sentence-transformers is required to generate embeddings")
+
 __all__ = [
     "Event",
     "EventType",
@@ -57,4 +63,5 @@ __all__ = [
     "ssl_config",
     "VectorStore",
     "VectorStoreListener",
+    "generate_embedding",
 ]

--- a/src/ume/client.py
+++ b/src/ume/client.py
@@ -7,6 +7,7 @@ from jsonschema import ValidationError
 from .config import Settings
 
 from .event import Event, parse_event
+from .embedding import generate_embedding
 from .schema_utils import validate_event_dict
 
 
@@ -75,6 +76,11 @@ class UMEClient:
                     break
                 raise UMEClientError(f"Consumer error: {msg.error()}")
             data = json.loads(msg.value().decode("utf-8"))
+            payload = data.get("payload")
+            if isinstance(payload, dict):
+                text_values = [v for v in payload.values() if isinstance(v, str)]
+                if text_values:
+                    payload["embedding"] = generate_embedding(" ".join(text_values))
             yield parse_event(data)
 
     def close(self) -> None:

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     UME_AUDIT_LOG_PATH: str = "audit.log"
     UME_AUDIT_SIGNING_KEY: str = "default-key"
     UME_AGENT_ID: str = "SYSTEM"
+    UME_EMBED_MODEL: str = "all-MiniLM-L6-v2"
 
     # Vector store
     UME_VECTOR_DIM: int = 1536

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -13,6 +13,7 @@ from ume.config import settings
 from ume.utils import ssl_config
 from confluent_kafka import Consumer, KafkaException, KafkaError  # type: ignore
 from ume import parse_event, EventError  # Import parse_event and EventError
+from ume.embedding import generate_embedding
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -73,6 +74,11 @@ def main():
             data = msg.value().decode("utf-8")
             try:
                 event_data_dict = json.loads(data)
+                payload = event_data_dict.get("payload")
+                if isinstance(payload, dict):
+                    text_values = [v for v in payload.values() if isinstance(v, str)]
+                    if text_values:
+                        payload["embedding"] = generate_embedding(" ".join(text_values))
                 received_event = parse_event(event_data_dict)
                 logger.info(f"Received event object: {received_event}")
             except json.JSONDecodeError as e:

--- a/src/ume/embedding.py
+++ b/src/ume/embedding.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from sentence_transformers import SentenceTransformer
+
+from .config import settings
+
+_MODEL_CACHE: dict[str, SentenceTransformer] = {}
+
+
+def _get_model() -> SentenceTransformer:
+    model_name = os.getenv("UME_EMBED_MODEL", settings.UME_EMBED_MODEL)
+    model = _MODEL_CACHE.get(model_name)
+    if model is None:
+        model = SentenceTransformer(model_name)
+        _MODEL_CACHE[model_name] = model
+    return model
+
+
+def generate_embedding(text: str) -> List[float]:
+    """Generate an embedding vector for ``text`` using Sentence Transformers."""
+    model = _get_model()
+    embedding = model.encode(text)
+    return embedding.tolist()

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,22 @@
+import importlib
+import sys
+import types
+
+from typing import List
+
+class DummyModel:
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+
+    def encode(self, text: str):  # pragma: no cover - simple stub
+        import numpy as np
+        return np.zeros(self.dim, dtype=float)
+
+
+def test_generate_embedding(monkeypatch):
+    dummy_module = types.SimpleNamespace(SentenceTransformer=lambda name: DummyModel(5))
+    monkeypatch.setitem(sys.modules, "sentence_transformers", dummy_module)
+    import ume.embedding as emb
+    importlib.reload(emb)
+    vec = emb.generate_embedding("hello")
+    assert vec == [0.0] * 5


### PR DESCRIPTION
## Summary
- add `generate_embedding` using sentence transformers
- integrate embedding generation into consumers
- expose embedding model via settings
- document optional embedding model setup
- test embedding generation

## Testing
- `ruff check src/ume/embedding.py src/ume/consumer_demo.py src/ume/client.py src/ume/__init__.py src/ume/config.py tests/test_embedding.py`
- `mypy src/ume/embedding.py src/ume/consumer_demo.py src/ume/client.py src/ume/__init__.py src/ume/config.py tests/test_embedding.py`
- `pytest tests/test_embedding.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851950d9e5483269cb6fdda1bd7f8db