### PR TITLE
Add API-driven graph demo

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,32 @@
 # UME Frontend
 
-This directory contains a minimal React application for visualizing a small graph.
-Open `index.html` in a browser to see sample nodes and edges rendered using the
-`vis-network` library.
+This directory contains a small React application that fetches graph data from
+the running UME API and visualizes it using `vis-network`.
+
+## Running the Demo
+
+1. **Start the API**
+
+   Launch the FastAPI server from the repository root:
+
+   ```bash
+   uvicorn ume.api:app --reload
+   ```
+
+   The default API token is `secret-token` (see `src/ume/config.py`).
+
+2. **Serve the Frontend**
+
+   In another terminal, start a simple static web server:
+
+   ```bash
+   cd frontend && python -m http.server 8001
+   ```
+
+   Then open `http://localhost:8001/index.html` in your browser.
+
+3. **Load the Graph**
+
+   Enter the API token when prompted and click **Load Graph** to fetch the
+   `/analytics/subgraph` endpoint. You can also input a comma-separated vector
+   to query `/vectors/search` via the optional search box.


### PR DESCRIPTION
## Summary
- fetch `/analytics/subgraph` with user token
- visualize nodes and edges via vis-network
- optional vector search using `/vectors/search`
- document running the demo

## Testing
- `pre-commit run --files frontend/index.js frontend/README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519513f1d8832694c197ea6a8cb2f2