### PR TITLE
Add frontend query UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ ID `"forbidden"`. Additional policies can be added by dropping new modules in
 git clone https://github.com/d0tTino/universal-memory-engine.git
 cd universal-memory-engine
 poetry install --with dev
+# Include optional embedding + vector dependencies to run the full test suite
+poetry install --with embedding --with vector
 poetry run python -m spacy download en_core_web_lg
 ```
 To automate the above steps (including installing development tools), you can
@@ -340,6 +342,21 @@ This example shows how an AutoDev agent can send events to UME and forward them
 to Culture.ai:
 ```bash
 poetry run python examples/agent_integration.py
+```
+
+### 8. Start the API and Frontend Demo
+Launch the FastAPI server and interact with it using either the
+web interface or the small CLI demo in `frontend/app.py`:
+
+```bash
+uvicorn ume.api:app --reload
+# open frontend/index.html in your browser (e.g. with `python -m http.server`)
+poetry run python frontend/app.py --token secret-token query "MATCH (n) RETURN n"
+```
+You can also search the vector store with either UI:
+
+```bash
+poetry run python frontend/app.py --token secret-token search "1,0,0" --k 3
 ```
 
 ## Configuration Templates

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,39 @@
+import argparse
+import json
+
+import httpx
+
+
+def run_query(api_url: str, token: str, cypher: str) -> None:
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = httpx.get(f"{api_url}/query", params={"cypher": cypher}, headers=headers)
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def search_vectors(api_url: str, token: str, vector: str, k: int) -> None:
+    headers = {"Authorization": f"Bearer {token}"}
+    floats = [float(x) for x in vector.split(',') if x.strip()]
+    params = [("vector", str(v)) for v in floats] + [("k", str(k))]
+    resp = httpx.get(f"{api_url}/vectors/search", params=params, headers=headers)
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with the UME API")
+    parser.add_argument("command", choices=["query", "search"], help="Operation to perform")
+    parser.add_argument("value", help="Cypher query or comma-separated vector")
+    parser.add_argument("--api-url", default="http://localhost:8000", help="Base API URL")
+    parser.add_argument("--token", required=True, help="API token")
+    parser.add_argument("--k", type=int, default=5, help="Neighbors to return when searching")
+    args = parser.parse_args()
+
+    if args.command == "query":
+        run_query(args.api_url, args.token, args.value)
+    else:
+        search_vectors(args.api_url, args.token, args.value, args.k)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,6 +3,9 @@ const { useState, useRef, useEffect } = React;
 function App() {
   const [token, setToken] = useState('');
   const [vector, setVector] = useState('');
+  const [cypher, setCypher] = useState('');
+  const [queryResult, setQueryResult] = useState('');
+  const [searchResult, setSearchResult] = useState('');
   const containerRef = useRef(null);
   const networkRef = useRef(null);
 
@@ -48,8 +51,24 @@ function App() {
       headers: { Authorization: 'Bearer ' + token },
     })
       .then((res) => res.json())
-      .then((data) => alert('Results: ' + data.ids.join(', ')))
+      .then((data) =>
+        setSearchResult(
+          Array.isArray(data.ids)
+            ? data.ids.join(', ')
+            : JSON.stringify(data, null, 2)
+        )
+      )
       .catch((err) => console.error('Search failed', err));
+  }
+
+  function runQuery() {
+    if (!cypher) return;
+    fetch('/query?cypher=' + encodeURIComponent(cypher), {
+      headers: { Authorization: 'Bearer ' + token },
+    })
+      .then((res) => res.json())
+      .then((data) => setQueryResult(JSON.stringify(data, null, 2)))
+      .catch((err) => console.error('Query failed', err));
   }
 
   return React.createElement(
@@ -69,6 +88,17 @@ function App() {
         'Load Graph'
       ),
       React.createElement('input', {
+        placeholder: 'Cypher query',
+        value: cypher,
+        onChange: (e) => setCypher(e.target.value),
+        style: { marginLeft: '8px', width: '40%' },
+      }),
+      React.createElement(
+        'button',
+        { onClick: runQuery, style: { marginLeft: '4px' } },
+        'Run Query'
+      ),
+      React.createElement('input', {
         placeholder: 'Vector search',
         value: vector,
         onChange: (e) => setVector(e.target.value),
@@ -79,6 +109,16 @@ function App() {
         { onClick: searchVectors, style: { marginLeft: '4px' } },
         'Search'
       )
+    ),
+    React.createElement(
+      'pre',
+      { style: { margin: 0, padding: '8px' } },
+      queryResult
+    ),
+    React.createElement(
+      'pre',
+      { style: { margin: 0, padding: '8px' } },
+      searchResult
     ),
     React.createElement('div', { ref: containerRef, style: { flex: 1 } })
   );


### PR DESCRIPTION
## Summary
- expand README instructions for running the frontend demo
- extend `frontend/index.js` with a Cypher query input and results display
- support showing vector search results inline
- add a simple CLI for invoking the API
- document installing optional extras needed for the full test suite

## Testing
- `poetry run pre-commit run --files frontend/app.py frontend/index.js README.md`
- `poetry run pytest -q` *(fails: several CLI tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5eb0f6c8326aa28ba3ae69b8d6a