### PR TITLE
Add VectorStore save/load tests and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
-        run: poetry install --no-interaction --no-ansi --with dev
+        run: poetry install --no-interaction --no-ansi --with dev --with vector --with embedding
 
       - name: Run pre-commit
         if: steps.changes.outputs.run == 'true'

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -50,6 +50,34 @@ class VectorStore:
         _, indices = self.index.search(arr, min(k, len(self.idx_to_id)))
         return [self.idx_to_id[i] for i in indices[0] if i != -1]
 
+    def save(self, path: str) -> None:
+        """Persist the FAISS index and id mapping to ``path``."""
+        index = self.index
+        # ``write_index`` only operates on CPU indexes.
+        if self.gpu_resources is not None:
+            index = faiss.index_gpu_to_cpu(index)
+        faiss.write_index(index, path)
+        with open(f"{path}.json", "w", encoding="utf-8") as f:
+            import json
+
+            json.dump(self.idx_to_id, f)
+
+    @classmethod
+    def load(cls, path: str, *, use_gpu: bool | None = None) -> "VectorStore":
+        """Load a previously saved index from ``path``."""
+        index = faiss.read_index(path)
+        dim = index.d
+        store = cls(dim=dim, use_gpu=use_gpu)
+        if store.gpu_resources is not None:
+            index = faiss.index_cpu_to_gpu(store.gpu_resources, 0, index)
+        store.index = index
+        with open(f"{path}.json", "r", encoding="utf-8") as f:
+            import json
+
+            store.idx_to_id = json.load(f)
+        store.id_to_idx = {item_id: i for i, item_id in enumerate(store.idx_to_id)}
+        return store
+
 
 class VectorStoreListener(GraphListener):
     """GraphListener that indexes embeddings from node attributes."""

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,4 +1,5 @@
 import time
+import importlib
 from ume import Event, EventType, MockGraph, apply_event_to_graph
 from ume.vector_store import VectorStore, VectorStoreListener
 from ume._internal.listeners import register_listener, unregister_listener
@@ -49,3 +50,27 @@ def test_vector_store_env_gpu(monkeypatch) -> None:
 
     store = vs.VectorStore(dim=2)
     assert store.gpu_resources is not None
+
+
+@pytest.mark.parametrize(
+    "env_gpu",
+    [False, True] if hasattr(faiss, "StandardGpuResources") else [False],
+)
+def test_vector_store_save_load(tmp_path, monkeypatch, env_gpu) -> None:
+    if env_gpu:
+        monkeypatch.setenv("UME_VECTOR_USE_GPU", "true")
+    else:
+        monkeypatch.setenv("UME_VECTOR_USE_GPU", "false")
+
+    import ume.config as cfg
+    import ume.vector_store as vs
+    importlib.reload(cfg)
+    importlib.reload(vs)
+
+    store = vs.VectorStore(dim=2)
+    store.add("a", [1.0, 0.0])
+    index_path = tmp_path / "index.faiss"
+    store.save(str(index_path))
+
+    loaded = vs.VectorStore.load(str(index_path))
+    assert loaded.query([1.0, 0.0], k=1) == ["a"]


### PR DESCRIPTION
## Summary
- implement save/load methods for VectorStore
- test VectorStore save/load with optional GPU support
- install optional extras in CI so GPU tests run

## Testing
- `pre-commit run --files src/ume/vector_store.py tests/test_vector_store.py .github/workflows/ci.yml`
- `pytest -q tests/test_vector_store.py`


------
https://chatgpt.com/codex/tasks/task_e_6851edd5e5548326aa93617bdd2469cc