### PR TITLE
Add GPU memory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,9 @@ Set the following environment variables to configure the store:
 - `UME_VECTOR_INDEX` – path of the FAISS index file.
 - `UME_VECTOR_USE_GPU` – set to `true` to build the index on a GPU (requires
   FAISS compiled with GPU support).
+- `UME_VECTOR_GPU_MEM_MB` – temporary memory (in MB) allocated for FAISS GPU
+operations (default `256`). Increase or decrease this to tune GPU memory usage
+when building the index.
 
 Install the optional dependencies with:
 

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     UME_VECTOR_DIM: int = 1536
     UME_VECTOR_INDEX: str = "vectors.faiss"
     UME_VECTOR_USE_GPU: bool = False
+    UME_VECTOR_GPU_MEM_MB: int = 256
 
     # Kafka/Redpanda
     KAFKA_BOOTSTRAP_SERVERS: str = "localhost:9092"

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -28,6 +28,9 @@ class VectorStore:
         if use_gpu:
             try:
                 self.gpu_resources = faiss.StandardGpuResources()
+                self.gpu_resources.setTempMemory(
+                    settings.UME_VECTOR_GPU_MEM_MB * 1024 * 1024
+                )
                 self.index = faiss.index_cpu_to_gpu(self.gpu_resources, 0, self.index)
             except AttributeError:
                 # FAISS was compiled without GPU support


### PR DESCRIPTION
## Summary
- add a GPU temporary memory setting to `Settings`
- configure GPU temp memory in `VectorStore`
- document `UME_VECTOR_GPU_MEM_MB`
- test GPU temp memory setting in `VectorStore`
- clarify README description of the GPU memory option

## Testing
- `pre-commit run --files src/ume/config.py src/ume/vector_store.py tests/test_vector_store.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851edd7ba048326902504dd34b03d8d