### PR TITLE
Add Prometheus metrics for VectorStore

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -51,3 +51,16 @@ Start the stack with `docker-compose up`. Prometheus will scrape
 2. Add a Prometheus data source pointing to `http://prometheus:9090`.
 3. Create a dashboard and add graphs using the `ume_http_requests_total` and
    other metrics exposed by UME.
+
+## Example Grafana Panels
+
+Here are a few Prometheus queries you can use when building graphs:
+
+| Metric | Purpose | Example Query |
+| ------ | ------- | ------------- |
+| `ume_request_latency_seconds` | Average request latency | `rate(ume_request_latency_seconds_sum[5m]) / rate(ume_request_latency_seconds_count[5m])` |
+| `ume_vector_query_latency_seconds` | Latency of vector similarity search | `rate(ume_vector_query_latency_seconds_sum[5m]) / rate(ume_vector_query_latency_seconds_count[5m])` |
+| `ume_vector_index_size` | Number of vectors stored | `ume_vector_index_size` |
+
+You can combine these metrics in Grafana to visualize API performance and index
+growth over time.

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse, Response
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     Counter,
+    Gauge,
     Histogram,
     generate_latest,
 )
@@ -42,6 +43,16 @@ REQUEST_LATENCY = Histogram(
     "ume_request_latency_seconds",
     "Request latency in seconds",
     ["method", "path"],
+)
+
+# Metrics for vector search operations
+VECTOR_QUERY_LATENCY = Histogram(
+    "ume_vector_query_latency_seconds",
+    "VectorStore query latency in seconds",
+)
+VECTOR_INDEX_SIZE = Gauge(
+    "ume_vector_index_size",
+    "Number of vectors stored in the VectorStore",
 )
 
 


### PR DESCRIPTION
## Summary
- monitor VectorStore queries via Prometheus
- expose vector index size metric
- include example Grafana queries in monitoring docs
- avoid heavy imports by moving metric import inside `query`

## Testing
- `pre-commit run --files src/ume/vector_store.py src/ume/api.py docs/MONITORING.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851edd6f8108326a715c9c9e60e2cea