### PR TITLE
Add auth docs and unauthorized tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,19 @@ You can also search the vector store with either UI:
 poetry run python frontend/app.py --token secret-token search "1,0,0" --k 3
 ```
 
+### API Authentication
+
+All HTTP endpoints exposed by the FastAPI service require a `Bearer` token,
+configured via the `UME_API_TOKEN` environment variable. Include it in the
+`Authorization` header of each request:
+
+```http
+Authorization: Bearer <token>
+```
+
+The only unauthenticated route is `/metrics`, which exposes Prometheus metrics.
+See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for a sample `.env` file.
+
 ## Configuration Templates
 
 Sample configuration files for common environments are provided in

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+import pytest
 
 from ume.api import app, configure_graph
 from ume import MockGraph
@@ -95,3 +96,36 @@ def test_metrics_endpoint():
     client = TestClient(app)
     res = client.get("/metrics")
     assert res.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "method,path,body,params",
+    [
+        ("post", "/analytics/shortest_path", {"source": "a", "target": "b"}, None),
+        ("post", "/analytics/path", {"source": "a", "target": "b"}, None),
+        ("post", "/analytics/subgraph", {"start": "a", "depth": 1}, None),
+        ("post", "/redact/node/a", None, None),
+        ("post", "/redact/edge", {"source": "a", "target": "b", "label": "L"}, None),
+        ("post", "/nodes", {"id": "x"}, None),
+        ("patch", "/nodes/a", {"attributes": {}}, None),
+        ("delete", "/nodes/a", None, None),
+        ("post", "/edges", {"source": "a", "target": "b", "label": "L"}, None),
+        ("delete", "/edges/a/b/L", None, None),
+        (
+            "get",
+            "/vectors/search",
+            None,
+            [("vector", 0.0), ("vector", 0.0)],
+        ),
+    ],
+)
+def test_endpoints_require_authentication(method, path, body, params):
+    client = TestClient(app)
+    request = getattr(client, method)
+    if method == "get":
+        res = request(path, params=params)
+    elif body is not None:
+        res = request(path, json=body)
+    else:
+        res = request(path)
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- document API authentication in README
- add parameterized tests ensuring endpoints require a token

## Testing
- `ruff check README.md tests/test_api.py`
- `mypy tests/test_api.py`
- `pytest tests/test_api.py tests/test_vector_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685212a3a0ac8326ae9296e2ba6f2c45