### PR TITLE
Refactor metrics handling

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -25,6 +25,12 @@ from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
 from .utils import ssl_config
 from .vector_store import VectorStore, VectorStoreListener
+from .metrics import (
+    REQUEST_COUNT,
+    REQUEST_LATENCY,
+    VECTOR_INDEX_SIZE,
+    VECTOR_QUERY_LATENCY,
+)
 
 try:  # Optional dependency
     from .embedding import generate_embedding
@@ -63,5 +69,9 @@ __all__ = [
     "ssl_config",
     "VectorStore",
     "VectorStoreListener",
+    "REQUEST_COUNT",
+    "REQUEST_LATENCY",
+    "VECTOR_QUERY_LATENCY",
+    "VECTOR_INDEX_SIZE",
     "generate_embedding",
 ]

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -10,13 +10,9 @@ from typing import Any, Dict, List
 import time
 from fastapi import Depends, FastAPI, HTTPException, Header, Query, Request
 from fastapi.responses import JSONResponse, Response
-from prometheus_client import (
-    CONTENT_TYPE_LATEST,
-    Counter,
-    Gauge,
-    Histogram,
-    generate_latest,
-)
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from .metrics import REQUEST_COUNT, REQUEST_LATENCY
 from pydantic import BaseModel
 
 from .analytics import shortest_path
@@ -35,26 +31,6 @@ app = FastAPI(
     description="HTTP API for the Universal Memory Engine.",
 )
 
-REQUEST_COUNT = Counter(
-    "ume_http_requests_total",
-    "Total HTTP requests",
-    ["method", "path", "status"],
-)
-REQUEST_LATENCY = Histogram(
-    "ume_request_latency_seconds",
-    "Request latency in seconds",
-    ["method", "path"],
-)
-
-# Metrics for vector search operations
-VECTOR_QUERY_LATENCY = Histogram(
-    "ume_vector_query_latency_seconds",
-    "VectorStore query latency in seconds",
-)
-VECTOR_INDEX_SIZE = Gauge(
-    "ume_vector_index_size",
-    "Number of vectors stored in the VectorStore",
-)
 
 
 @app.middleware("http")

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -1,0 +1,23 @@
+from prometheus_client import Counter, Histogram, Gauge
+
+# HTTP metrics
+REQUEST_COUNT = Counter(
+    "ume_http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status"],
+)
+REQUEST_LATENCY = Histogram(
+    "ume_request_latency_seconds",
+    "Request latency in seconds",
+    ["method", "path"],
+)
+
+# Vector store metrics
+VECTOR_QUERY_LATENCY = Histogram(
+    "ume_vector_query_latency_seconds",
+    "VectorStore query latency in seconds",
+)
+VECTOR_INDEX_SIZE = Gauge(
+    "ume_vector_index_size",
+    "Number of vectors stored in the VectorStore",
+)


### PR DESCRIPTION
## Summary
- move Prometheus metric declarations into new `metrics` module
- inject metrics into `VectorStore` via constructor or `set_metrics`
- expose metrics from `ume.__init__`
- update API to use new metrics module

## Testing
- `ruff check src/ume/metrics.py src/ume/api.py src/ume/vector_store.py src/ume/__init__.py`
- `mypy src/ume/metrics.py src/ume/api.py src/ume/vector_store.py src/ume/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685212ba2dbc8326a78e7e6141e30dd4