### PR TITLE
Document env vars and unify config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ poetry run python frontend/app.py --token secret-token search "1,0,0" --k 3
 Sample configuration files for common environments are provided in
 [`docs/CONFIG_TEMPLATES.md`](docs/CONFIG_TEMPLATES.md). These templates
 demonstrate how to select different storage backends or event stores for
-development, staging, and production setups.
+development, staging, and production setups. The same document also lists
+every environment variable understood by UME along with its default value.
 
 ### Runtime Settings
 

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -50,3 +50,39 @@ faust:
   edge_topic: "ume_edges"
   node_topic: "ume_nodes"
 ```
+
+## Environment Variables
+
+UME can also be configured via environment variables or a `.env` file. The table
+below lists all available variables and their default values.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UME_DB_PATH` | `ume_graph.db` | SQLite database used by `PersistentGraph`. |
+| `UME_SNAPSHOT_PATH` | `ume_snapshot.json` | Path to graph snapshot file. |
+| `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |
+| `UME_AUDIT_SIGNING_KEY` | `default-key` | Key used to sign audit entries. |
+| `UME_AGENT_ID` | `SYSTEM` | Identifier recorded in audit logs. |
+| `UME_EMBED_MODEL` | `all-MiniLM-L6-v2` | SentenceTransformer model name. |
+| `UME_CLI_DB` | `ume_graph.db` | Database path used by the CLI. |
+| `UME_ROLE` | *(unset)* | Optional role for the CLI. |
+| `UME_API_ROLE` | *(unset)* | Optional role applied by the API server. |
+| `UME_VECTOR_DIM` | `1536` | Dimension of embedding vectors. |
+| `UME_VECTOR_INDEX` | `vectors.faiss` | FAISS index file path. |
+| `UME_VECTOR_USE_GPU` | `False` | Whether to build the index on a GPU. |
+| `UME_VECTOR_GPU_MEM_MB` | `256` | GPU memory used when building the index. |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Comma separated list of Kafka brokers. |
+| `KAFKA_RAW_EVENTS_TOPIC` | `ume-raw-events` | Topic for raw events. |
+| `KAFKA_CLEAN_EVENTS_TOPIC` | `ume-clean-events` | Topic for sanitized events. |
+| `KAFKA_QUARANTINE_TOPIC` | `ume-quarantine-events` | Topic for rejected events. |
+| `KAFKA_EDGE_TOPIC` | `ume_edges` | Topic for processed edges. |
+| `KAFKA_NODE_TOPIC` | `ume_nodes` | Topic for processed nodes. |
+| `KAFKA_GROUP_ID` | `ume_client_group` | Consumer group for demos and stream processors. |
+| `KAFKA_PRIVACY_AGENT_GROUP_ID` | `ume-privacy-agent-group` | Consumer group for the privacy agent. |
+| `KAFKA_PRODUCER_BATCH_SIZE` | `10` | Number of messages before producer flush. |
+| `UME_API_TOKEN` | `secret-token` | Token required by the API server. |
+| `UME_LOG_LEVEL` | `INFO` | Logging level used by `configure_logging`. |
+| `UME_LOG_JSON` | `False` | Output logs as JSON lines when set to `True`. |
+| `KAFKA_CA_CERT` | *(unset)* | CA certificate for Kafka TLS. |
+| `KAFKA_CLIENT_CERT` | *(unset)* | Client certificate for Kafka TLS. |
+| `KAFKA_CLIENT_KEY` | *(unset)* | Client key for Kafka TLS. |

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     UME_AUDIT_SIGNING_KEY: str = "default-key"
     UME_AGENT_ID: str = "SYSTEM"
     UME_EMBED_MODEL: str = "all-MiniLM-L6-v2"
+    UME_CLI_DB: str = "ume_graph.db"
+    UME_ROLE: str | None = None
+    UME_API_ROLE: str | None = None
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -35,6 +38,15 @@ class Settings(BaseSettings):
 
     # API
     UME_API_TOKEN: str = "secret-token"
+
+    # Logging
+    UME_LOG_LEVEL: str = "INFO"
+    UME_LOG_JSON: bool = False
+
+    # Optional Kafka TLS certificates
+    KAFKA_CA_CERT: str | None = None
+    KAFKA_CLIENT_CERT: str | None = None
+    KAFKA_CLIENT_KEY: str | None = None
 
 
 # Create a single, importable instance

--- a/src/ume/logging_utils.py
+++ b/src/ume/logging_utils.py
@@ -1,7 +1,7 @@
 import logging
-import os
-
 import structlog
+
+from .config import settings
 
 
 def configure_logging(
@@ -19,13 +19,12 @@ def configure_logging(
         environment variable (``"1"``, ``"true"``).
     """
     if level is None:
-        level = os.getenv("UME_LOG_LEVEL", "INFO")
+        level = settings.UME_LOG_LEVEL
     if isinstance(level, str):
         level = getattr(logging, level.upper(), logging.INFO)
 
     if json_logs is None:
-        json_env = os.getenv("UME_LOG_JSON", "0").lower()
-        json_logs = json_env in {"1", "true", "yes"}
+        json_logs = settings.UME_LOG_JSON
 
     processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import logging
-import os
 import shlex
 import sys
 import time  # Added for timestamp in event creation
@@ -46,9 +45,9 @@ class UMEPrompt(Cmd):
 
     def __init__(self):
         super().__init__()
-        db_path = os.environ.get("UME_CLI_DB", settings.UME_DB_PATH)
+        db_path = settings.UME_CLI_DB
         base_graph = PersistentGraph(db_path)
-        role = os.environ.get("UME_ROLE")
+        role = settings.UME_ROLE
         if role:
             print(f"INFO: UME-CLI running with role: '{role}'")
             graph: IGraphAdapter = RoleBasedGraphAdapter(base_graph, role)


### PR DESCRIPTION
## Summary
- list every configurable environment variable in `CONFIG_TEMPLATES.md`
- reference env var table from the README quickstart
- add logging, CLI and TLS settings to config defaults
- read CLI settings via the `Settings` object
- use `Settings` values in logging config

## Testing
- `pre-commit run --files README.md docs/CONFIG_TEMPLATES.md src/ume/config.py src/ume/logging_utils.py ume_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685212babb10832686b5fb7e28db6e34