### PR TITLE
Implement DAG executor with resource locks

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -25,6 +25,7 @@ from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
 from .utils import ssl_config
 from .vector_store import VectorStore, VectorStoreListener
+from .dag_executor import Task, DAGExecutor
 
 try:  # Optional dependency
     from .embedding import generate_embedding
@@ -64,4 +65,6 @@ __all__ = [
     "VectorStore",
     "VectorStoreListener",
     "generate_embedding",
+    "Task",
+    "DAGExecutor",
 ]

--- a/src/ume/dag_executor.py
+++ b/src/ume/dag_executor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Any, Dict, List, Optional
+import threading
+
+
+@dataclass
+class Task:
+    """A unit of work in the DAG."""
+
+    name: str
+    func: Callable[[], Any]
+    dependencies: List[str] = field(default_factory=list)
+    resource: str = "cpu"
+
+
+class DAGExecutor:
+    """Execute tasks respecting dependencies and resource limits."""
+
+    def __init__(self, resources: Optional[Dict[str, int]] = None) -> None:
+        self.tasks: Dict[str, Task] = {}
+        self.resources = resources or {"cpu": 1, "gpu": 0}
+        self.locks: Dict[str, threading.Semaphore] = {
+            name: threading.Semaphore(count) for name, count in self.resources.items()
+        }
+
+    def add_task(self, task: Task) -> None:
+        if task.name in self.tasks:
+            raise ValueError(f"Task {task.name} already exists")
+        self.tasks[task.name] = task
+
+    def _topological_sort(self) -> List[str]:
+        remaining: Dict[str, set[str]] = {
+            name: set(task.dependencies) for name, task in self.tasks.items()
+        }
+        order: List[str] = []
+        while remaining:
+            ready = [name for name, deps in remaining.items() if not deps]
+            if not ready:
+                raise ValueError("Cycle detected in task graph")
+            for name in ready:
+                order.append(name)
+                del remaining[name]
+            for deps in remaining.values():
+                for finished in ready:
+                    deps.discard(finished)
+        return order
+
+    def run(self) -> Dict[str, Any]:
+        remaining: Dict[str, set[str]] = {
+            name: set(task.dependencies) for name, task in self.tasks.items()
+        }
+        results: Dict[str, Any] = {}
+        while remaining:
+            ready = [name for name, deps in remaining.items() if not deps]
+            if not ready:
+                raise ValueError("Cycle detected in task graph")
+            threads = []
+            for name in ready:
+                task = self.tasks[name]
+                try:
+                    sem = self.locks[task.resource]
+                except KeyError as exc:
+                    raise ValueError(f"Unknown resource {task.resource}") from exc
+
+                def worker(
+                    n: str = name,
+                    t: Task = task,
+                    sem_lock: threading.Semaphore = sem,
+                ) -> None:
+                    with sem_lock:
+                        results[n] = t.func()
+
+                thread = threading.Thread(target=worker)
+                thread.start()
+                threads.append(thread)
+            for thread in threads:
+                thread.join()
+            for name in ready:
+                del remaining[name]
+            for deps in remaining.values():
+                for finished in ready:
+                    deps.discard(finished)
+        return results

--- a/tests/test_dag_executor.py
+++ b/tests/test_dag_executor.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import time
+
+DAG_SPEC = importlib.util.spec_from_file_location(
+    "ume.dag_executor", "src/ume/dag_executor.py"
+)
+assert DAG_SPEC is not None and DAG_SPEC.loader is not None
+dag_executor = importlib.util.module_from_spec(DAG_SPEC)
+sys.modules["ume.dag_executor"] = dag_executor
+DAG_SPEC.loader.exec_module(dag_executor)
+DAGExecutor = dag_executor.DAGExecutor
+Task = dag_executor.Task
+
+
+def test_dag_execution_order():
+    order: list[str] = []
+
+    def a():
+        order.append("a")
+
+    def b():
+        order.append("b")
+
+    def c():
+        order.append("c")
+
+    exec = DAGExecutor()
+    exec.add_task(Task(name="a", func=a))
+    exec.add_task(Task(name="b", func=b, dependencies=["a"]))
+    exec.add_task(Task(name="c", func=c, dependencies=["b"]))
+    exec.run()
+    assert order == ["a", "b", "c"]
+
+
+def test_resource_scheduling_sequential_gpu():
+    exec = DAGExecutor(resources={"cpu": 1, "gpu": 1})
+    events: list[tuple[str, float]] = []
+
+    def make(name: str, delay: float, resource: str):
+        def _f():
+            events.append((name + "_start", time.perf_counter()))
+            time.sleep(delay)
+            events.append((name + "_end", time.perf_counter()))
+        return Task(name=name, func=_f, resource=resource)
+
+    exec.add_task(make("gpu1", 0.1, "gpu"))
+    exec.add_task(make("gpu2", 0.1, "gpu"))
+    exec.run()
+
+    starts = [t for t in events if t[0].endswith("_start")]
+    assert len(starts) == 2
+    diff = starts[1][1] - starts[0][1]
+    assert diff >= 0.09


### PR DESCRIPTION
## Summary
- add `DAGExecutor` and `Task` for executing DAGs with simple resource-aware scheduling
- expose new classes via package `__all__`
- implement tests covering DAG ordering and GPU resource constraints

## Testing
- `ruff check src/ume/dag_executor.py src/ume/__init__.py tests/test_dag_executor.py`
- `poetry run mypy src/ume/dag_executor.py src/ume/__init__.py tests/test_dag_executor.py`
- `PYTHONPATH=src pytest -q tests/test_dag_executor.py`

------
https://chatgpt.com/codex/tasks/task_e_685212c84b6083269b32eedf006b7a9f