### PR TITLE
Add module to pillar mapping diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ poetry install --with dev
 ## Architecture
 
 This section provides a high-level overview of the Universal Memory Engine (UME) demo setup.
+For a diagram that shows how each module maps to the pillars in the roadmap, see [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md).
 
 The current system consists of the following main components:
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -25,3 +25,52 @@ When FAISS is compiled with GPU support, setting the environment variable
 `UME_VECTOR_USE_GPU=true` transfers the index to GPU memory. Benchmarks with
 100k vectors show roughly a **5x** reduction in query latency compared to CPU
 search.
+
+## Component Interactions
+
+The API interfaces with the graph adapter layer and the vector store to answer
+queries. The diagram below highlights how these core modules connect.
+
+```mermaid
+graph TD
+    PrivacyAgent(Privacy Agent) --> Adapter(Graph Adapter)
+    Adapter --> GraphDB[(Graph Storage)]
+    Adapter --> VectorStore[(Vector Store)]
+    API(FastAPI Service) --> Adapter
+    API --> VectorStore
+```
+
+## Modules and Roadmap Pillars
+
+The [ROADMAP](../ROADMAP.md) defines "Exocortic Eudaemon" pillars guiding the
+project. This diagram links major modules to those pillars.
+
+```mermaid
+flowchart LR
+    subgraph Pillars
+        Memory
+        EthicalSafeguards[Ethical Safeguards]
+        ProductiveCollaboration[Productive Collaboration]
+        SelfImprovement[Self-Improvement]
+        OperationalResilience[Operational Resilience]
+    end
+    subgraph Modules
+        PrivacyAgentM[Privacy Agent]
+        GraphAdapters[Graph Adapters]
+        VectorStoreM[Vector Store]
+        APIService[API]
+    end
+    PrivacyAgentM --> EthicalSafeguards
+    GraphAdapters --> Memory
+    VectorStoreM --> Memory
+    APIService --> ProductiveCollaboration
+```
+
+* **Privacy Agent** – implements **Ethical Safeguards** by redacting sensitive
+  data before it is stored.
+* **Graph Adapters** and **Vector Store** – provide persistent **Memory** for
+  the knowledge graph and its embeddings.
+* **API** – enables **Productive Collaboration** by exposing graph and vector
+  search endpoints.
+* The **Self-Improvement** and **Operational Resilience** pillars are primarily
+  addressed by automation and infrastructure work described in the roadmap.


### PR DESCRIPTION
## Summary
- map modules to roadmap pillars and component interactions in Architecture Overview
- cross-link the new diagram from README

## Testing
- `pre-commit run --files README.md docs/ARCHITECTURE_OVERVIEW.md`


------
https://chatgpt.com/codex/tasks/task_e_685212d5b4ac83269733d20afa860f0a