### PR TITLE
Add metrics dashboard endpoints

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,3 +30,9 @@ the running UME API and visualizes it using `vis-network`.
    Enter the API token when prompted and click **Load Graph** to fetch the
    `/analytics/subgraph` endpoint. You can also input a comma-separated vector
    to query `/vectors/search` via the optional search box.
+
+4. **View Metrics**
+
+   Use **Load Stats** to display node and edge counts along with vector index
+   size. Click **Recent Events** to fetch the latest audit log entries, shown
+   with the most recent first.

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,4 +1,4 @@
-const { useState, useRef, useEffect } = React;
+const { useState, useRef } = React;
 
 function App() {
   const [token, setToken] = useState('');
@@ -6,6 +6,8 @@ function App() {
   const [cypher, setCypher] = useState('');
   const [queryResult, setQueryResult] = useState('');
   const [searchResult, setSearchResult] = useState('');
+  const [stats, setStats] = useState(null);
+  const [events, setEvents] = useState([]);
   const containerRef = useRef(null);
   const networkRef = useRef(null);
 
@@ -71,6 +73,24 @@ function App() {
       .catch((err) => console.error('Query failed', err));
   }
 
+  function loadStats() {
+    fetch('/dashboard/stats', {
+      headers: { Authorization: 'Bearer ' + token },
+    })
+      .then((res) => res.json())
+      .then((data) => setStats(data))
+      .catch((err) => console.error('Failed to load stats', err));
+  }
+
+  function loadEvents() {
+    fetch('/dashboard/recent_events', {
+      headers: { Authorization: 'Bearer ' + token },
+    })
+      .then((res) => res.json())
+      .then((data) => setEvents(data))
+      .catch((err) => console.error('Failed to load events', err));
+  }
+
   return React.createElement(
     'div',
     { style: { height: '100%', display: 'flex', flexDirection: 'column' } },
@@ -108,6 +128,16 @@ function App() {
         'button',
         { onClick: searchVectors, style: { marginLeft: '4px' } },
         'Search'
+      ),
+      React.createElement(
+        'button',
+        { onClick: loadStats, style: { marginLeft: '4px' } },
+        'Load Stats'
+      ),
+      React.createElement(
+        'button',
+        { onClick: loadEvents, style: { marginLeft: '4px' } },
+        'Recent Events'
       )
     ),
     React.createElement(
@@ -120,6 +150,18 @@ function App() {
       { style: { margin: 0, padding: '8px' } },
       searchResult
     ),
+    stats &&
+      React.createElement(
+        'pre',
+        { style: { margin: 0, padding: '8px' } },
+        JSON.stringify(stats, null, 2)
+      ),
+    events.length > 0 &&
+      React.createElement(
+        'pre',
+        { style: { margin: 0, padding: '8px' } },
+        JSON.stringify(events, null, 2)
+      ),
     React.createElement('div', { ref: containerRef, style: { flex: 1 } })
   );
 }


### PR DESCRIPTION
## Summary
- expand React frontend to view graph metrics
- expose dashboard endpoints for stats and recent events
- document metrics in frontend README
- remove unused React import
- reverse order of recent events in API

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685212c94d588326aeaa32b017eff8d8