### PR TITLE
Add metrics arguments to VectorStore

### DIFF
--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -26,6 +26,8 @@ class VectorStore:
         use_gpu: bool | None = None,
         path: str | None = None,
         flush_interval: float | None = None,
+        query_latency_metric: Histogram | None = None,
+        index_size_metric: Gauge | None = None,
 
     ) -> None:
         self.path = path or settings.UME_VECTOR_INDEX
@@ -38,6 +40,8 @@ class VectorStore:
         self._flush_interval = flush_interval
         self._flush_thread: threading.Thread | None = None
         self._flush_stop = threading.Event()
+        self.query_latency_metric = query_latency_metric
+        self.index_size_metric = index_size_metric
 
 
         self.index = faiss.IndexFlatL2(dim)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -4,6 +4,8 @@ from ume.vector_store import VectorStore, VectorStoreListener
 from ume._internal.listeners import register_listener, unregister_listener
 import faiss
 import pytest
+from pathlib import Path
+from prometheus_client import Gauge, Histogram
 
 
 def test_vector_store_add_and_query_cpu() -> None:
@@ -36,7 +38,7 @@ def test_vector_store_gpu_init() -> None:
     VectorStore(dim=2, use_gpu=True)
 
 
-def test_vector_store_env_gpu(monkeypatch) -> None:
+def test_vector_store_env_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     if not hasattr(faiss, "StandardGpuResources"):
         pytest.skip("FAISS GPU not available")
 
@@ -52,7 +54,7 @@ def test_vector_store_env_gpu(monkeypatch) -> None:
     assert store.gpu_resources is not None
 
 
-def test_vector_store_gpu_mem_setting(monkeypatch) -> None:
+def test_vector_store_gpu_mem_setting(monkeypatch: pytest.MonkeyPatch) -> None:
     if not hasattr(faiss, "StandardGpuResources"):
         pytest.skip("FAISS GPU not available")
 
@@ -81,7 +83,7 @@ def test_vector_store_gpu_mem_setting(monkeypatch) -> None:
     assert store.gpu_resources.temp == 1 * 1024 * 1024
 
 
-def test_vector_store_save_and_load(tmp_path) -> None:
+def test_vector_store_save_and_load(tmp_path: Path) -> None:
     path = tmp_path / "index.faiss"
     store = VectorStore(dim=2, use_gpu=False, path=str(path))
     store.add("x", [1.0, 0.0])
@@ -93,7 +95,7 @@ def test_vector_store_save_and_load(tmp_path) -> None:
     assert new_store.query([1.0, 0.0], k=1) == ["x"]
 
 
-def test_vector_store_add_persist(tmp_path) -> None:
+def test_vector_store_add_persist(tmp_path: Path) -> None:
     path = tmp_path / "persist.faiss"
     store = VectorStore(dim=2, use_gpu=False, path=str(path))
     store.add("y", [1.0, 0.0], persist=True)
@@ -104,7 +106,7 @@ def test_vector_store_add_persist(tmp_path) -> None:
     assert new_store.query([1.0, 0.0], k=1) == ["y"]
 
 
-def test_vector_store_background_flush(tmp_path) -> None:
+def test_vector_store_background_flush(tmp_path: Path) -> None:
     path = tmp_path / "bg.faiss"
     store = VectorStore(dim=2, use_gpu=False, path=str(path), flush_interval=0.1)
     store.add("z", [0.0, 1.0])
@@ -115,3 +117,16 @@ def test_vector_store_background_flush(tmp_path) -> None:
     new_store.load(str(path))
 
     assert new_store.query([0.0, 1.0], k=1) == ["z"]
+
+
+def test_vector_store_metrics_init() -> None:
+    lat = Histogram("test_query_latency", "desc")
+    size = Gauge("test_index_size", "desc")
+    store = VectorStore(
+        dim=2,
+        use_gpu=False,
+        query_latency_metric=lat,
+        index_size_metric=size,
+    )
+    assert store.query_latency_metric is lat
+    assert store.index_size_metric is size


### PR DESCRIPTION
## Summary
- allow `VectorStore.__init__` to accept optional metrics
- update vector store tests and add regression test

## Testing
- `pre-commit run --files src/ume/vector_store.py tests/test_vector_store.py`
- `PYTHONPATH=src pytest -q tests/test_vector_store.py`

------
https://chatgpt.com/codex/tasks/task_e_685225f27da88326b11ad92245a4d34f