### PR TITLE
Add read-only token permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- restrict CI workflow token permissions to contents read
- allow writing actions artifacts and caches

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852fec3b3f48326b86ccc8af20919da