### PR TITLE
Fix merge queue config

### DIFF
--- a/.github/merge_queue.yml
+++ b/.github/merge_queue.yml
@@ -3,6 +3,5 @@ merge_queue:
     - name: default
       merge_method: squash
       required_checks:
-        - "CI / test-and-lint (3.11)"
         - "CI / test-and-lint (3.12)"
         - "CI / coverage"


### PR DESCRIPTION
## Summary
- drop unused 3.11 test-and-lint check from merge queue

## Testing
- `poetry run pre-commit run --files .github/merge_queue.yml`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685333ec36448326acac9fb29496d0a5