### PR TITLE
Add pre-commit step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: poetry install --no-interaction --no-ansi --with dev --extras vector --extras embedding
 
+      - name: Run pre-commit
+        if: steps.changes.outputs.run == 'true'
+        run: poetry run pre-commit run --show-diff-on-failure --color always
+
       - name: Run Ruff
         if: steps.changes.outputs.run == 'true'
         run: poetry run ruff check . --config pyproject.toml
@@ -128,6 +132,10 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
         run: poetry install --no-interaction --no-ansi --with dev --extras vector --extras embedding
+
+      - name: Run pre-commit
+        if: steps.changes.outputs.run == 'true'
+        run: poetry run pre-commit run --show-diff-on-failure --color always
 
       - name: Run Ruff
         if: steps.changes.outputs.run == 'true'


### PR DESCRIPTION
## Summary
- run `pre-commit` as part of the CI workflow after dependency installation

## Testing
- `poetry run ruff check . --config pyproject.toml`
- `poetry run mypy --config-file mypy.ini`
- `poetry run pytest`
- `poetry run pre-commit run --show-diff-on-failure --color always`


------
https://chatgpt.com/codex/tasks/task_e_68533daa91b483269fd640f3700785e6