### PR TITLE
Update CI to rely on pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,7 @@ jobs:
 
       - name: Run pre-commit
         if: steps.changes.outputs.run == 'true'
-        run: poetry run pre-commit run --show-diff-on-failure --color always
-
-      - name: Run Ruff
-        if: steps.changes.outputs.run == 'true'
-        run: poetry run ruff check . --config pyproject.toml
-
-      - name: Run mypy
-        if: steps.changes.outputs.run == 'true'
-        run: poetry run mypy --config-file mypy.ini
+        run: poetry run pre-commit run --all-files --show-diff-on-failure --color always
 
       - name: Run tests
         if: steps.changes.outputs.run == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (though currently in pre-release/development phase).
 
+## [0.1.1] - 2025-06-19
+### Changed
+- CI now runs `pre-commit` across all files, removing separate Ruff and mypy steps.
+
 ## [0.1.0] - 2025-06-09
 ### Added
 -   `PersistentGraph` SQLite-backed adapter replacing the in-memory `MockGraph`.

--- a/examples/agent_integration.py
+++ b/examples/agent_integration.py
@@ -25,7 +25,7 @@ def autodev_produce_event(client: UMEClient) -> None:
     client.produce_event(event)
 
 
-def forward_to_culture(events) -> None:
+def forward_to_culture(events: list[Event]) -> None:
     """Placeholder step forwarding events to Culture.ai."""
     for event in events:
         logger.info("Forwarding event %s to Culture.ai", event.event_id)

--- a/imp_compat.py
+++ b/imp_compat.py
@@ -21,7 +21,7 @@ def new_module(name: str) -> types.ModuleType:
     return types.ModuleType(name)
 
 
-def load_module(name: str):
+def load_module(name: str) -> types.ModuleType:
     spec = importlib.util.find_spec(name)
     if spec is None or spec.loader is None:
         raise ImportError(name)


### PR DESCRIPTION
## Summary
- run ruff and mypy via pre-commit across all files
- remove duplicate Ruff and mypy steps
- document new CI behavior
- fix mypy errors so pre-commit passes

## Testing
- `poetry run pre-commit run --all-files --show-diff-on-failure --color always`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68535c1741988326baa2e5edb46a8f66