### PR TITLE
Fix Python setup step skip logic in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           scripts/ci_should_run.py && echo "run=true" >> "$GITHUB_OUTPUT" || echo "run=false" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python and install dependencies
+        if: steps.changes.outputs.run == 'true'
         uses: ./.github/actions/setup-python-poetry
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- skip setup-python-poetry when CI run is unnecessary

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685364bbf23483269524b0f93d19563e