### PR TITLE
Enable manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+  workflow_dispatch:
+
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- allow maintainers to manually run the CI workflow

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685364c02aa08326a6966d8fd9423ee3