### PR TITLE
Fix audit log error handling

### DIFF
--- a/src/ume/audit.py
+++ b/src/ume/audit.py
@@ -8,8 +8,10 @@ from typing import List, Dict
 
 try:
     import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
 except Exception:  # pragma: no cover - boto3 optional
     boto3 = None
+    BotoCoreError = ClientError = Exception
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +36,8 @@ def _read_lines(path: str) -> List[str]:
         try:
             obj = s3.get_object(Bucket=bucket, Key=key)
             data = obj["Body"].read().decode()
-        except Exception:
+        except (BotoCoreError, ClientError, UnicodeDecodeError) as exc:
+            logger.error("Failed to read audit log from %s: %s", path, exc)
             return []
         return data.splitlines()
     else:


### PR DESCRIPTION
## Summary
- add specific exception handling for reading from S3
- log S3 read errors for audit log
- test log message for failed S3 reads

## Testing
- `pre-commit run --files src/ume/audit.py tests/test_audit_logging.py`
- `pytest tests/test_audit_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853707a21b88326a2cd90c8b49ba7ae