### PR TITLE
Handle exceptions in DAGExecutor worker threads

### DIFF
--- a/tests/test_dag_executor.py
+++ b/tests/test_dag_executor.py
@@ -59,3 +59,17 @@ def test_public_imports() -> None:
 
     assert PublicDAGExecutor is DAGExecutor
     assert PublicTask is Task
+
+
+def test_run_raises_on_task_error() -> None:
+    exec = DAGExecutor()
+
+    exec.add_task(Task(name="ok", func=lambda: None))
+
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    exec.add_task(Task(name="bad", func=boom))
+
+    with pytest.raises(RuntimeError):
+        exec.run()


### PR DESCRIPTION
## Summary
- capture errors in DAGExecutor worker threads
- re-raise captured errors so failures surface to callers
- add unit test covering task failures
- avoid catching `BaseException` in worker function

## Testing
- `pre-commit run --files src/ume/dag_executor.py tests/test_dag_executor.py`
- `pytest tests/test_dag_executor.py -k test_run_raises_on_task_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68537078e36c8326836d0274e732a25b