### PR TITLE
Add disabling for periodic snapshots

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -6,6 +6,7 @@ from .persistent_graph import PersistentGraph
 from .neo4j_graph import Neo4jGraph
 from .auto_snapshot import (
     enable_periodic_snapshot,
+    disable_periodic_snapshot,
     enable_snapshot_autosave_and_restore,
 )
 from .graph_adapter import IGraphAdapter
@@ -74,6 +75,7 @@ __all__ = [
     "SnapshotError",
     "enable_snapshot_autosave_and_restore",
     "enable_periodic_snapshot",
+    "disable_periodic_snapshot",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -1,41 +1,73 @@
 import atexit
 import threading
-import time
 from pathlib import Path
 from typing import Union
 import logging
+from collections.abc import Callable
 from .graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
 
 logger = logging.getLogger(__name__)
 
 
+_periodic_snapshot_thread: threading.Thread | None = None
+_periodic_snapshot_stop_event: threading.Event | None = None
+
+
 def enable_periodic_snapshot(
     graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600
-) -> None:
-    """Enable periodic snapshotting and snapshot on shutdown."""
+) -> tuple[threading.Thread, Callable[[], None]]:
+    """Enable periodic snapshotting and snapshot on shutdown.
+
+    Returns the background thread used for snapshotting and a function to stop
+    it.
+    """
+    global _periodic_snapshot_thread, _periodic_snapshot_stop_event
+
     snapshot_path = Path(path)
 
     def _snapshot() -> None:
         try:
             snapshot_graph_to_file(graph, snapshot_path)
         except Exception:  # pragma: no cover - don't raise during shutdown
-
             pass
 
+    stop_event = threading.Event()
+
     def _run() -> None:
-        while True:
-            time.sleep(interval_seconds)
+        while not stop_event.wait(interval_seconds):
             _snapshot()
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
     atexit.register(_snapshot)
 
+    _periodic_snapshot_thread = thread
+    _periodic_snapshot_stop_event = stop_event
+
+    def stop() -> None:
+        stop_event.set()
+        thread.join()
+
+    return thread, stop
+
+
+def disable_periodic_snapshot() -> None:
+    """Stop the periodic snapshot thread if running."""
+    global _periodic_snapshot_thread, _periodic_snapshot_stop_event
+
+    if _periodic_snapshot_stop_event is not None:
+        _periodic_snapshot_stop_event.set()
+    if _periodic_snapshot_thread is not None:
+        _periodic_snapshot_thread.join()
+
+    _periodic_snapshot_thread = None
+    _periodic_snapshot_stop_event = None
+
 
 def enable_snapshot_autosave_and_restore(
     graph: IGraphAdapter, path: Union[str, Path], interval_seconds: int = 3600
-) -> None:
+) -> tuple[threading.Thread, Callable[[], None]]:
     """Restore graph from snapshot if present and enable periodic autosave."""
 
     snapshot_path = Path(path)
@@ -46,4 +78,4 @@ def enable_snapshot_autosave_and_restore(
         except Exception as e:  # pragma: no cover - logging only
             logger.warning("Failed to restore snapshot from %s: %s", snapshot_path, e)
 
-    enable_periodic_snapshot(graph, snapshot_path, interval_seconds)
+    return enable_periodic_snapshot(graph, snapshot_path, interval_seconds)

--- a/tests/test_auto_snapshot.py
+++ b/tests/test_auto_snapshot.py
@@ -13,11 +13,48 @@ def test_enable_snapshot_autosave_logs_warning(tmp_path, caplog, monkeypatch):
         raise ValueError("load error")
 
     monkeypatch.setattr(auto_snapshot, "load_graph_into_existing", raise_error)
+    sentinel_thread = object()
+    sentinel_stop = object()
     monkeypatch.setattr(
-        auto_snapshot, "enable_periodic_snapshot", lambda *args, **kwargs: None
+        auto_snapshot,
+        "enable_periodic_snapshot",
+        lambda *args, **kwargs: (sentinel_thread, sentinel_stop),
     )
 
     with caplog.at_level(logging.WARNING):
-        auto_snapshot.enable_snapshot_autosave_and_restore(graph, snapshot_file)
+        result = auto_snapshot.enable_snapshot_autosave_and_restore(graph, snapshot_file)
 
+    assert result == (sentinel_thread, sentinel_stop)
     assert any("Failed to restore snapshot" in rec.message for rec in caplog.records)
+
+
+def test_disable_periodic_snapshot(monkeypatch, tmp_path):
+    import ume.auto_snapshot as auto_snapshot
+
+    events: dict[str, bool] = {}
+
+    class DummyEvent:
+        def wait(self, timeout: float | None = None) -> bool:
+            return False
+
+        def set(self) -> None:
+            events["set"] = True
+
+    class DummyThread:
+        def __init__(self, target=None, daemon=None) -> None:
+            self._target = target
+
+        def start(self) -> None:  # pragma: no cover - noop in test
+            pass
+
+        def join(self) -> None:
+            events["joined"] = True
+
+    monkeypatch.setattr(auto_snapshot.threading, "Event", DummyEvent)
+    monkeypatch.setattr(auto_snapshot.threading, "Thread", DummyThread)
+
+    graph = PersistentGraph(":memory:")
+    thread, stop = auto_snapshot.enable_periodic_snapshot(graph, tmp_path / "snap.json", 1)
+    auto_snapshot.disable_periodic_snapshot()
+
+    assert events.get("set") and events.get("joined")


### PR DESCRIPTION
## Summary
- update snapshot API to return its thread and stop callable
- adjust autosave restore wrapper and tests

## Testing
- `pre-commit run --files src/ume/auto_snapshot.py src/ume/__init__.py tests/test_auto_snapshot.py`
- `pytest tests/test_auto_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68537845f2f88326950af78e8be74ba0