### PR TITLE
Improve S3 path parsing

### DIFF
--- a/src/ume/audit.py
+++ b/src/ume/audit.py
@@ -20,7 +20,20 @@ SIGNING_KEY = settings.UME_AUDIT_SIGNING_KEY.encode()
 
 
 def _parse_s3(path: str) -> tuple[str, str]:
-    _, rest = path.split("://", 1)
+    """Return the bucket and key from an S3 path."""
+
+    prefix = "s3://"
+    if not path.startswith(prefix):
+        raise ValueError(
+            f"Invalid S3 path: '{path}'. Expected format 's3://bucket/key'."
+        )
+
+    rest = path[len(prefix) :]
+    if "/" not in rest:
+        raise ValueError(
+            f"Invalid S3 path: '{path}'. Expected format 's3://bucket/key'."
+        )
+
     bucket, key = rest.split("/", 1)
     return bucket, key
 

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -114,3 +114,26 @@ def test_s3_read_logs_error(monkeypatch, caplog):
     assert any(
         "Failed to read audit log from s3://bucket/key" in rec.message for rec in caplog.records
     )
+
+
+def test_parse_s3_valid() -> None:
+    from ume.audit import _parse_s3
+
+    bucket, key = _parse_s3("s3://my-bucket/path/to/key")
+    assert bucket == "my-bucket"
+    assert key == "path/to/key"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "bucket/key",  # missing scheme
+        "s3://bucket",  # missing key
+        "gs://bucket/key",  # wrong scheme
+    ],
+)
+def test_parse_s3_invalid(path: str) -> None:
+    from ume.audit import _parse_s3
+
+    with pytest.raises(ValueError):
+        _parse_s3(path)


### PR DESCRIPTION
## Summary
- validate S3 path format strictly against the `s3://bucket/key` pattern
- add test ensuring a wrong scheme raises `ValueError`

## Testing
- `pre-commit run --files src/ume/audit.py tests/test_audit_logging.py`
- `pytest -q tests/test_audit_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_6853784525188326ac653b4cd5d63b79