### PR TITLE
Configure self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-and-lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check out code
         uses: actions/checkout@v4 # Updated to v4

--- a/README.md
+++ b/README.md
@@ -433,3 +433,7 @@ If you have questions, encounter issues, or want to discuss ideas related to UME
 
 *   **Open an Issue:** For bug reports, feature requests, or specific questions, please check the [GitHub Issues](https://github.com/your-username/universal-memory-engine/issues) page (please replace `your-username/universal-memory-engine` with the actual repository path).
 *   **Check our Contributing Guide:** For information on how to contribute to the project, see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## Setting Up a Self-hosted Runner
+
+The CI workflow expects a runner with the `self-hosted` label. If you haven't configured one yet, follow the instructions in [docs/SELF_HOSTED_RUNNER.md](docs/SELF_HOSTED_RUNNER.md) to register a machine as a GitHub Actions runner.

--- a/docs/SELF_HOSTED_RUNNER.md
+++ b/docs/SELF_HOSTED_RUNNER.md
@@ -1,0 +1,18 @@
+# Configuring a Self-hosted Runner
+
+This project uses GitHub Actions for continuous integration. The default workflow assumes a runner is available with the `self-hosted` label. Follow these steps to provision one, based on GitHub's documentation:
+
+1. **Navigate to your repository's settings.** Under **Actions** > **Runners**, click **Add runner**.
+2. **Choose the appropriate operating system** and download the runner package on the machine you want to use.
+3. **Extract the archive** and run the `config.sh` script. The setup page will provide a command similar to:
+   ```bash
+   ./config.sh --url https://github.com/<owner>/<repo> --token <generated-token>
+   ```
+   Replace `<owner>` and `<repo>` with the repository path and `<generated-token>` with the token provided in the GitHub UI.
+4. **Start the runner** using:
+   ```bash
+   ./run.sh
+   ```
+   The runner will connect to GitHub and listen for workflow jobs labeled `self-hosted`.
+
+For more details and troubleshooting steps, see the [GitHub Actions documentation](https://docs.github.com/actions/hosting-your-own-runners/about-self-hosted-runners).


### PR DESCRIPTION
## Summary
- run CI on a self-hosted runner
- document how to configure a self-hosted runner

## Testing
- `pytest -q`
- `ruff check src tests`
- `ruff format --check src tests`


------
https://chatgpt.com/codex/tasks/task_e_685472ee0e44832683ae8cb097f8f374