### PR TITLE
Handle invalid timestamps gracefully

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "mypy.ini"]
+        additional_dependencies: ["types-PyYAML"]

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Set, cast
 
 import networkx as nx
 import numpy as np
@@ -167,11 +167,13 @@ def temporal_node_counts(graph: IGraphAdapter, past_n_days: int) -> Dict[str, in
     for node_id in graph.get_all_node_ids():
         data = graph.get_node(node_id) or {}
         ts = data.get("timestamp")
-        if isinstance(ts, (int, float)):
-            dt = datetime.fromtimestamp(int(ts), timezone.utc)
-            if dt >= cutoff:
-                key = dt.date().isoformat()
-                buckets[key] = buckets.get(key, 0) + 1
+        try:
+            dt = datetime.fromtimestamp(int(cast(Any, ts)), timezone.utc)
+        except (TypeError, ValueError):
+            continue
+        if dt >= cutoff:
+            key = dt.date().isoformat()
+            buckets[key] = buckets.get(key, 0) + 1
     return buckets
 
 

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -80,7 +80,10 @@ def extract_subgraph(
         include = True
         if since_timestamp is not None:
             ts = data.get("timestamp")
-            if ts is None or int(ts) < since_timestamp:
+            try:
+                if int(cast(Any, ts)) < since_timestamp:
+                    include = False
+            except (TypeError, ValueError):
                 include = False
         if include:
             nodes[node] = data.copy()
@@ -157,7 +160,10 @@ class GraphAlgorithmsMixin:
                 if since_timestamp is not None:
                     data = self.get_node(neighbor) or {}
                     ts = data.get("timestamp")
-                    if ts is None or int(ts) < since_timestamp:
+                    try:
+                        if int(cast(Any, ts)) < since_timestamp:
+                            continue
+                    except (TypeError, ValueError):
                         continue
                 visited[neighbor] = node
                 queue.append((neighbor, depth + 1))

--- a/tests/test_traversal_methods.py
+++ b/tests/test_traversal_methods.py
@@ -34,6 +34,13 @@ def test_extract_subgraph():
     assert set(recent["nodes"].keys()) == {"c", "d"}
 
 
+def test_extract_subgraph_with_invalid_timestamp():
+    g = build_graph()
+    g.update_node("b", {"timestamp": "not-a-number"})
+    recent = g.extract_subgraph("a", depth=2, since_timestamp=3)
+    assert set(recent["nodes"].keys()) == {"c", "d"}
+
+
 def test_constrained_path():
     g = build_graph()
     assert g.constrained_path("a", "c", max_depth=2) == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- handle invalid `timestamp` values by skipping nodes when parsing fails
- add a regression test for invalid timestamps in `extract_subgraph`
- ensure mypy pre-commit hook installs `types-PyYAML`

## Testing
- `pre-commit run --files src/ume/graph_algorithms.py src/ume/analytics.py tests/test_traversal_methods.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685495422964832690c3f17b6f3d264b