### PR TITLE
Fix update_node redacted check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "mypy.ini"]
+        additional_dependencies: ["types-PyYAML"]

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -47,7 +47,9 @@ class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(f"Node '{node_id}' already exists.")
 
     def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
-        cur = self.conn.execute("SELECT attributes FROM nodes WHERE id=?", (node_id,))
+        cur = self.conn.execute(
+            "SELECT attributes FROM nodes WHERE id=? AND redacted=0", (node_id,)
+        )
         row = cur.fetchone()
         if row is None:
             raise ProcessingError(f"Node '{node_id}' not found for update.")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -90,6 +90,17 @@ def test_update_node_non_existent_raises_error(graph: PersistentGraph):
         graph.update_node(node_id, attributes)
 
 
+def test_update_node_redacted_raises_error(graph: PersistentGraph):
+    """Test that updating a redacted node raises ProcessingError."""
+    node_id = "node_redacted"
+    graph.add_node(node_id, {"name": "hidden"})
+    graph.redact_node(node_id)
+    with pytest.raises(
+        ProcessingError, match=f"Node '{node_id}' not found for update."
+    ):
+        graph.update_node(node_id, {"name": "update"})
+
+
 # --- get_node tests ---
 def test_get_node_exists(graph: PersistentGraph):
     """Test get_node for an existing node."""


### PR DESCRIPTION
## Summary
- avoid updating redacted nodes in PersistentGraph
- test update_node on redacted nodes
- ensure mypy pre-commit hook installs PyYAML stubs

## Testing
- `pre-commit run --files src/ume/persistent_graph.py tests/test_graph.py .pre-commit-config.yaml`
- `pytest tests/test_graph.py::test_update_node_redacted_raises_error -q`

------
https://chatgpt.com/codex/tasks/task_e_685495375ea48326a95ebed7dc83c8cc