### PR TITLE
Fix warnings log path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,8 @@ Please refer to the `README.md` for instructions on setting up your development 
 3. Create a feature branch and implement your changes.
 4. Before committing, run the checks locally:
    ```bash
-   pre-commit run --all-files
-   pytest
+  pre-commit run --all-files
+  poetry run pytest
    ```
 5. Push your branch and open a pull request.
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -8,6 +8,7 @@ import sys
 import time  # Added for timestamp in event creation
 import warnings
 from pathlib import Path
+import os
 
 # Ensure local package import when run directly without installation
 _src_path = Path(__file__).resolve().parent / "src"
@@ -427,6 +428,9 @@ def _setup_warnings(display: bool, log_file: str | None) -> None:
 
     logger = None
     if log_file:
+        dir_path = os.path.dirname(log_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
         logger = logging.getLogger("ume_cli.warnings")
         handler = logging.FileHandler(log_file)
         logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- import os in ume_cli
- create log directories with os.makedirs when a warnings log is provided
- document using `poetry run pytest` in CONTRIBUTING

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68549e460ec88326919b384e6243dd01