### PR TITLE
Fix edge filter for Neo4jGraph

### DIFF
--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -110,11 +110,13 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(f"Node '{node_id}' not found.")
         with self._driver.session() as session:
             if edge_label:
+                escaped_label = edge_label.replace("`", "``")
                 query = (
-                    "MATCH (n {id: $node_id})-[r:$label]->(m) "
-                    "WHERE coalesce(m.redacted, false) = false RETURN m.id AS id"
+                    f"MATCH (n {{id: $node_id}})-[r:`{escaped_label}`]->(m) "
+                    "WHERE coalesce(r.redacted, false) = false "
+                    "AND coalesce(m.redacted, false) = false RETURN m.id AS id"
                 )
-                result = session.run(query, {"node_id": node_id, "label": edge_label})
+                result = session.run(query, {"node_id": node_id})
             else:
                 query = (
                     "MATCH (n {id: $node_id})-[r]->(m) "

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -314,6 +314,26 @@ def test_find_connected_nodes_no_matching_edges(graph: MockGraph):
     assert graph.find_connected_nodes("n3") == []
 
 
+def test_find_connected_nodes_ignores_redacted_edge_unlabeled(graph: PersistentGraph) -> None:
+    """Redacted edges should not appear in unlabeled queries."""
+    graph.add_node("s", {})
+    graph.add_node("t", {})
+    graph.add_edge("s", "t", "L")
+    graph.redact_edge("s", "t", "L")
+
+    assert graph.find_connected_nodes("s") == []
+
+
+def test_find_connected_nodes_ignores_redacted_edge_labeled(graph: PersistentGraph) -> None:
+    """Redacted edges should not appear in labeled queries."""
+    graph.add_node("s", {})
+    graph.add_node("t", {})
+    graph.add_edge("s", "t", "L")
+    graph.redact_edge("s", "t", "L")
+
+    assert graph.find_connected_nodes("s", edge_label="L") == []
+
+
 # --- delete_edge tests (New) ---
 def test_delete_edge_success(graph: PersistentGraph):
     """Test deleting an existing edge successfully."""


### PR DESCRIPTION
## Summary
- filter redacted edges when searching by label
- test `find_connected_nodes` with redacted edges using PersistentGraph
- ensure Neo4j queries filter redacted relationships
- embed edge labels directly in Cypher query

## Testing
- `pre-commit run --files src/ume/neo4j_graph.py tests/test_neo4j_graph.py tests/test_graph.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b958307483269be8d594a99febf7