### PR TITLE
Add vector dimension validation

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -322,6 +322,8 @@ def api_add_vector(
     store: VectorStore = Depends(get_vector_store),
 ) -> Dict[str, Any]:
     """Store an embedding vector for later similarity search."""
+    if len(req.vector) != store.dim:
+        raise HTTPException(status_code=400, detail="Invalid vector dimension")
     store.add(req.id, req.vector)
     return {"status": "ok"}
 
@@ -334,6 +336,8 @@ def api_search_vectors(
     store: VectorStore = Depends(get_vector_store),
 ) -> Dict[str, Any]:
     """Find the IDs of the ``k`` nearest vectors to ``vector``."""
+    if len(vector) != store.dim:
+        raise HTTPException(status_code=400, detail="Invalid vector dimension")
     ids = store.query(vector, k=k)
     return {"ids": ids}
 

--- a/tests/test_vector_api.py
+++ b/tests/test_vector_api.py
@@ -20,6 +20,18 @@ def test_add_vector_authorized() -> None:
     assert app.state.vector_store.query([0.0, 1.0], k=1) == ["v1"]
 
 
+def test_add_vector_invalid_dimension() -> None:
+    configure_vector_store(VectorStore(dim=2, use_gpu=False))
+    client = TestClient(app)
+    res = client.post(
+        "/vectors",
+        json={"id": "v_bad", "vector": [0.0]},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Invalid vector dimension"
+
+
 def test_add_vector_unauthorized() -> None:
     configure_vector_store(VectorStore(dim=2, use_gpu=False))
     client = TestClient(app)
@@ -41,6 +53,20 @@ def test_search_vectors() -> None:
     )
     assert res.status_code == 200
     assert res.json()["ids"] == ["b", "c"]
+
+
+def test_search_vectors_invalid_dimension() -> None:
+    configure_vector_store(VectorStore(dim=2, use_gpu=False))
+    client = TestClient(app)
+    store = app.state.vector_store
+    store.add("a", [0, 0])
+    res = client.get(
+        "/vectors/search",
+        params=[("vector", 1.1)],
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Invalid vector dimension"
 
 
 def test_benchmark_endpoint():


### PR DESCRIPTION
## Summary
- validate vector dimensions in `api_add_vector` and `api_search_vectors`
- test that invalid dimensions return HTTP 400 with a clear message

## Testing
- `ruff check src/ume/api.py tests/test_vector_api.py`
- `mypy --config-file mypy.ini src/ume/api.py tests/test_vector_api.py`
- `pytest tests/test_vector_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6854b9621200832690d844cefc54f140