### PR TITLE
Validate query input for VectorStore

### DIFF
--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List
+from collections.abc import Iterable
+import numbers
 import json
 import logging
 
@@ -160,6 +162,12 @@ class VectorStore:
         try:
             if not self.idx_to_id:
                 return []
+            if (
+                not isinstance(vector, Iterable)
+                or isinstance(vector, (str, bytes))
+                or not all(isinstance(v, numbers.Real) for v in vector)
+            ):
+                raise ValueError("vector must be an iterable of numbers")
             arr = np.asarray(vector, dtype="float32").reshape(1, -1)
             if arr.shape[1] != self.dim:
                 raise ValueError(

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -6,6 +6,7 @@ from ume._internal.listeners import register_listener, unregister_listener
 import faiss
 import pytest
 from pathlib import Path
+from typing import Any
 from prometheus_client import Gauge, Histogram
 
 
@@ -189,3 +190,19 @@ def test_configure_vector_store_replacement_closes_existing(tmp_path: Path) -> N
     assert store1._flush_thread is None
     assert app.state.vector_store is store2
     store2.close()
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        "not a vector",
+        [1.0, "a"],
+        [[1.0, 2.0]],
+    ],
+)
+def test_vector_store_query_invalid_input(vector: Any) -> None:
+    store = VectorStore(dim=2, use_gpu=False)
+    store.add("a", [1.0, 0.0])
+
+    with pytest.raises(ValueError, match="iterable of numbers"):
+        store.query(vector)


### PR DESCRIPTION
## Summary
- validate vector input in `VectorStore.query`
- raise `ValueError` when the vector isn't numeric
- test query with invalid vectors

## Testing
- `ruff check src/ume/vector_store.py tests/test_vector_store.py`
- `mypy --config-file mypy.ini src/ume/vector_store.py tests/test_vector_store.py`
- `pytest tests/test_vector_store.py -k test_vector_store_query_invalid_input -vv`

------
https://chatgpt.com/codex/tasks/task_e_68557aac88d083268b12e0dc9d0548c5