### PR TITLE
Add duplicate detection when loading graph snapshots

### DIFF
--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -1,11 +1,21 @@
 # src/ume/snapshot.py
 import json
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Any
 import pathlib  # For type hinting path-like objects
 
 from .persistent_graph import PersistentGraph
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
+
+
+def _no_duplicate_pairs_hook(pairs: List[Tuple[str, Any]]) -> dict:
+    """Object pairs hook for ``json.load`` that rejects duplicate keys."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SnapshotError(f"Duplicate key '{key}' encountered in snapshot.")
+        result[key] = value
+    return result
 
 
 class SnapshotError(ValueError):
@@ -65,7 +75,7 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
     """
     try:
         with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+            data = json.load(f, object_pairs_hook=_no_duplicate_pairs_hook)
     except FileNotFoundError:
         raise FileNotFoundError(f"Snapshot file not found at path: {path}")
     except json.JSONDecodeError as e:
@@ -89,12 +99,16 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
         )
 
     graph = PersistentGraph(":memory:")
+    seen_node_ids = set()
     for node_id, attributes in data["nodes"].items():
+        if node_id in seen_node_ids:
+            raise SnapshotError(f"Duplicate node ID '{node_id}' encountered in snapshot.")
         if not isinstance(attributes, dict):
             raise SnapshotError(
                 f"Invalid snapshot format for node '{node_id}': attributes should be a dictionary, "
                 f"got {type(attributes).__name__}."
             )
+        seen_node_ids.add(node_id)
         # Since MockGraph.add_node expects attributes to be Dict[str, Any],
         # and json.load ensures keys are strings, this should be fine.
         graph.add_node(node_id, attributes.copy())  # Use .copy() for attributes
@@ -107,6 +121,7 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
             )
 
         loaded_edges: List[Tuple[str, str, str]] = []
+        seen_edges = set()
         for i, edge_data in enumerate(data["edges"]):
             if not isinstance(edge_data, (list, tuple)):
                 raise SnapshotError(
@@ -123,7 +138,13 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> PersistentGraph:
                     f"Invalid snapshot format for edge at index {i}: all edge elements "
                     f"(source, target, label) must be strings."
                 )
-            loaded_edges.append(tuple(edge_data))
+            edge_tuple = tuple(edge_data)
+            if edge_tuple in seen_edges:
+                raise SnapshotError(
+                    f"Duplicate edge {edge_tuple} encountered in snapshot."
+                )
+            seen_edges.add(edge_tuple)
+            loaded_edges.append(edge_tuple)
 
         # Use public API to add edges for consistency
         for src, tgt, lbl in loaded_edges:

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -389,3 +389,33 @@ def test_load_graph_from_file_edge_references_missing_node(tmp_path: pathlib.Pat
     pattern = re.escape(expected_msg)
     with pytest.raises(SnapshotError, match=pattern):
         load_graph_from_file(snapshot_file)
+
+
+def test_load_graph_from_file_duplicate_edge(tmp_path: pathlib.Path):
+    """Duplicate edges in the snapshot should raise SnapshotError."""
+    snapshot_file = tmp_path / "duplicate_edge.json"
+    snapshot_data = {
+        "nodes": {"n1": {}, "n2": {}},
+        "edges": [("n1", "n2", "REL"), ("n1", "n2", "REL")],
+    }
+    with open(snapshot_file, "w", encoding="utf-8") as f:
+        json.dump(snapshot_data, f)
+
+    expected_msg = "Duplicate edge ('n1', 'n2', 'REL') encountered in snapshot."
+    with pytest.raises(SnapshotError, match=re.escape(expected_msg)):
+        load_graph_from_file(snapshot_file)
+
+
+def test_load_graph_from_file_duplicate_node_id(tmp_path: pathlib.Path):
+    """Duplicate node IDs in the snapshot should raise SnapshotError."""
+    snapshot_file = tmp_path / "duplicate_node.json"
+    # Manually craft JSON with duplicate node keys
+    duplicate_json = (
+        '{"nodes": {"n1": {"a": 1}, "n1": {"b": 2}}, "edges": []}'
+    )
+    with open(snapshot_file, "w", encoding="utf-8") as f:
+        f.write(duplicate_json)
+
+    expected_msg = "Duplicate key 'n1' encountered in snapshot."
+    with pytest.raises(SnapshotError, match=re.escape(expected_msg)):
+        load_graph_from_file(snapshot_file)


### PR DESCRIPTION
## Summary
- reject duplicate nodes and edges when loading graph snapshots
- cover duplicate cases in graph serialization tests

## Testing
- `pre-commit run --files src/ume/snapshot.py tests/test_graph_serialization.py`
- `pytest tests/test_graph_serialization.py -k "duplicate_edge or duplicate_node_id" -q`

------
https://chatgpt.com/codex/tasks/task_e_68557ab0b7d48326bb8d2850550cfa69