### PR TITLE
Fix VectorStore path handling

### DIFF
--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 import json
 import logging
+import os
 
 import time
 import threading
@@ -34,6 +35,10 @@ class VectorStore:
 
     ) -> None:
         self.path = path or settings.UME_VECTOR_INDEX
+        if path:
+            dirpath = os.path.dirname(path)
+            if dirpath:
+                os.makedirs(dirpath, exist_ok=True)
         self.id_to_idx: Dict[str, int] = {}
         self.idx_to_id: List[str] = []
         self.gpu_resources = None

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -125,6 +125,15 @@ def test_vector_store_add_persist(tmp_path: Path) -> None:
     assert new_store.query([1.0, 0.0], k=1) == ["y"]
 
 
+def test_vector_store_save_creates_directory(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "save.faiss"
+    store = VectorStore(dim=2, use_gpu=False, path=str(path))
+    store.add("d", [1.0, 0.0])
+    store.save()
+
+    assert path.exists()
+
+
 def test_vector_store_background_flush(tmp_path: Path) -> None:
     path = tmp_path / "bg.faiss"
     store = VectorStore(dim=2, use_gpu=False, path=str(path), flush_interval=0.1)


### PR DESCRIPTION
## Summary
- create parent directory when VectorStore initialized with a path
- test saving to a nested path

## Testing
- `pre-commit run --files src/ume/vector_store.py tests/test_vector_store.py`
- `pytest tests/test_vector_store.py -k test_vector_store_save_creates_directory -q`

------
https://chatgpt.com/codex/tasks/task_e_68557ab41658832683c2ce57cf1bc346