### PR TITLE
Add schema upgrade transformations

### DIFF
--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -116,3 +116,25 @@ During initialization, indices on the `edges` table are created to
 speed up lookups. An index `idx_edges_source` is always created on the
 `source` column and an additional `idx_edges_target` index is created on
 the `target` column.
+
+## Schema Upgrades
+
+### Migrating from version 1.0.0 to 2.0.0
+
+UME provides the helper `GraphSchemaManager.upgrade_schema` to update both
+the schema definition and any stored data. When upgrading from `1.0.0` to
+`2.0.0` the following transformations occur:
+
+1. Edges labeled `L` are renamed to `LINKS_TO`.
+2. Edges labeled `TO_DELETE` are removed from the graph.
+
+Applications should instantiate a `GraphSchemaManager` and pass the graph
+instance when calling `upgrade_schema`:
+
+```python
+manager = GraphSchemaManager()
+schema = manager.upgrade_schema("1.0.0", "2.0.0", graph)
+```
+
+After the call, the provided graph will conform to the new schema and the
+returned schema object can be used for validating future events.

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -48,3 +48,18 @@ def test_apply_event_with_schema_version(graph: PersistentGraph):
 
     apply_event_to_graph(event, graph, schema_version="2.0.0")
     assert graph.node_exists("n1")
+
+
+def test_upgrade_transforms_graph(graph: PersistentGraph) -> None:
+    graph.add_node("a", {})
+    graph.add_node("b", {})
+    graph.add_edge("a", "b", "L")
+    graph.add_edge("b", "a", "TO_DELETE")
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("1.0.0", "2.0.0", graph)
+
+    edges = graph.get_all_edges()
+    assert ("a", "b", "LINKS_TO") in edges
+    assert all(lbl != "L" for _, _, lbl in edges)
+    assert all(lbl != "TO_DELETE" for _, _, lbl in edges)


### PR DESCRIPTION
## Summary
- support modifying graph data during schema upgrades
- detail migration instructions for upgrading to schema version 2.0.0
- test schema upgrade logic

## Testing
- `pre-commit run --files src/ume/schema_manager.py tests/test_schema_manager.py docs/GRAPH_MODEL.md`
- `UME_DOCKER_TESTS=0 pytest tests/test_schema_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855df73fa908326a7084c3a85885f38