### PR TITLE
Add record retention support

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -83,6 +83,7 @@ below lists all available variables and their default values.
 | `UME_API_TOKEN` | `secret-token` | Token required by the API server. |
 | `UME_LOG_LEVEL` | `INFO` | Logging level used by `configure_logging`. |
 | `UME_LOG_JSON` | `False` | Output logs as JSON lines when set to `True`. |
+| `UME_GRAPH_RETENTION_DAYS` | `30` | Age in days before old nodes/edges are purged. |
 | `KAFKA_CA_CERT` | *(unset)* | CA certificate for Kafka TLS. |
 | `KAFKA_CLIENT_CERT` | *(unset)* | Client certificate for Kafka TLS. |
 | `KAFKA_CLIENT_KEY` | *(unset)* | Client key for Kafka TLS. |

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     UME_API_ROLE: str | None = None
     UME_LOG_LEVEL: str = "INFO"
     UME_LOG_JSON: bool = False
+    UME_GRAPH_RETENTION_DAYS: int = 30
 
     # Vector store
     UME_VECTOR_DIM: int = 1536

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+import time
 
 from neo4j import GraphDatabase, Driver
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
@@ -44,8 +45,8 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
             if rec["cnt"] > 0:
                 raise ProcessingError(f"Node '{node_id}' already exists.")
             session.run(
-                "CREATE (n {id: $node_id}) SET n += $attrs",
-                {"node_id": node_id, "attrs": attributes},
+                "CREATE (n {id: $node_id, created_at:$ts}) SET n += $attrs",
+                {"node_id": node_id, "attrs": attributes, "ts": int(time.time())},
             )
 
     def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
@@ -153,8 +154,8 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
                     f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
                 )
             session.run(
-                f"MATCH (s {{id: $src}}), (t {{id: $tgt}}) CREATE (s)-[:`{escaped_label}` {{redacted:false}}]->(t)",
-                {"src": source_node_id, "tgt": target_node_id},
+                f"MATCH (s {{id: $src}}), (t {{id: $tgt}}) CREATE (s)-[:`{escaped_label}` {{redacted:false, created_at:$ts}}]->(t)",
+                {"src": source_node_id, "tgt": target_node_id, "ts": int(time.time())},
             )
 
     def get_all_edges(self) -> List[tuple[str, str, str]]:

--- a/tests/test_graph_retention.py
+++ b/tests/test_graph_retention.py
@@ -1,0 +1,32 @@
+import time
+
+from ume import PersistentGraph
+
+
+def test_persistent_graph_created_at_columns():
+    graph = PersistentGraph(":memory:")
+    cur = graph.conn.execute("PRAGMA table_info('nodes')")
+    cols = {row[1] for row in cur.fetchall()}
+    assert "created_at" in cols
+
+    cur = graph.conn.execute("PRAGMA table_info('edges')")
+    cols = {row[1] for row in cur.fetchall()}
+    assert "created_at" in cols
+
+
+def test_purge_old_records_removes_old_entries():
+    graph = PersistentGraph(":memory:")
+    graph.add_node("n1", {})
+    graph.add_node("n2", {})
+    graph.add_edge("n1", "n2", "LINK")
+
+    old_ts = int(time.time()) - 10 * 86400
+    with graph.conn:
+        graph.conn.execute("UPDATE nodes SET created_at=? WHERE id='n1'", (old_ts,))
+        graph.conn.execute("UPDATE edges SET created_at=?", (old_ts,))
+
+    graph.purge_old_records(5 * 86400)
+
+    assert not graph.node_exists("n1")
+    assert graph.node_exists("n2")
+    assert graph.get_all_edges() == []


### PR DESCRIPTION
## Summary
- add `created_at` timestamps to PersistentGraph tables
- store timestamp on Neo4j nodes and edges
- purge old records via new CLI command
- expose retention days setting and document config
- test purging old graph entries
- fix purge command when CLI uses role-based adapter

## Testing
- `pre-commit run --files ume_cli.py`
- `pytest tests/test_graph_retention.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855df7316208326a0b200cd11b44fb1