### PR TITLE
Fix failing tests after dependency installation

### DIFF
--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -8,7 +8,6 @@ from ume import (
     PersistentGraph,
     snapshot_graph_to_file,
     load_graph_from_file,
-    load_graph_into_existing,
     SnapshotError,
 )  # Add new imports
 

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -92,7 +92,9 @@ def test_add_edge_parameterized_label():
     assert label in check_query
     assert label in create_query
     assert check_params == {"src": "s1", "tgt": "t1"}
-    assert create_params == {"src": "s1", "tgt": "t1"}
+    assert create_params["src"] == "s1"
+    assert create_params["tgt"] == "t1"
+    assert isinstance(create_params.get("ts"), int)
 
 
 def test_add_node_duplicate_raises():

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -6,7 +6,6 @@ from ume._internal.listeners import register_listener, unregister_listener
 import faiss
 import pytest
 from pathlib import Path
-from typing import Any
 from prometheus_client import Gauge, Histogram
 import logging
 


### PR DESCRIPTION
## Summary
- update Neo4j edge creation test to account for timestamp parameter

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857952edd3c83269148346e044676d8