### PR TITLE
Add stop handling to DAG components

### DIFF
--- a/src/ume/dag_service.py
+++ b/src/ume/dag_service.py
@@ -18,12 +18,13 @@ class DAGService:
     def start(self) -> None:
         if self._thread:
             return
+        self._executor.reset_stop_flag()
         self._thread = threading.Thread(target=self._executor.run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
         if not self._thread:
             return
-        # DAGExecutor lacks a stop mechanism; tasks should exit on their own.
+        self._executor.stop()
         self._thread.join()
         self._thread = None

--- a/tests/test_dag_service.py
+++ b/tests/test_dag_service.py
@@ -12,3 +12,30 @@ def test_dag_service_start_stop() -> None:
     service.start()
     service.stop()
     assert ran == [1]
+
+
+def test_dag_service_stop_cancels_pending_tasks() -> None:
+    import time
+    import threading
+
+    ran: list[str] = []
+    started = threading.Event()
+
+    def slow() -> None:
+        started.set()
+        time.sleep(0.2)
+        ran.append("slow")
+
+    def should_not_run() -> None:
+        ran.append("fast")
+
+    service = DAGService(
+        [
+            Task(name="slow", func=slow),
+            Task(name="fast", func=should_not_run, dependencies=["slow"]),
+        ]
+    )
+    service.start()
+    started.wait(0.1)
+    service.stop()
+    assert ran == ["slow"]


### PR DESCRIPTION
## Summary
- let `DAGExecutor` cancel remaining tasks using a stop event
- allow `DAGService` to signal stop to the executor
- test that pending tasks do not run after a stop request

## Testing
- `pre-commit run --files src/ume/dag_executor.py src/ume/dag_service.py tests/test_dag_service.py`
- `pytest tests/test_dag_service.py -k test_dag_service_stop_cancels_pending_tasks -q`
- `pytest tests/test_dag_service.py::test_dag_service_start_stop -q`


------
https://chatgpt.com/codex/tasks/task_e_68581a2e49f483268a23de9bb592416e