### PR TITLE
Add SSE endpoint with rate limiting

### DIFF
--- a/examples/stream_client.py
+++ b/examples/stream_client.py
@@ -1,0 +1,23 @@
+"""Example consuming the path stream SSE endpoint."""
+
+import asyncio
+import httpx
+from ume.config import settings
+
+
+async def main() -> None:
+    async with httpx.AsyncClient(timeout=None) as client:
+        async with client.stream(
+            "GET",
+            "http://localhost:8000/analytics/path/stream",
+            params={"source": "a", "target": "b"},
+            headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+        ) as r:
+            async for line in r.aiter_lines():
+                if line.startswith("data: "):
+                    print("node", line[6:])
+                    await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,6 +2,7 @@ import argparse
 import json
 
 import httpx
+from httpx import QueryParams
 
 
 def run_query(api_url: str, token: str, cypher: str) -> None:
@@ -14,8 +15,13 @@ def run_query(api_url: str, token: str, cypher: str) -> None:
 def search_vectors(api_url: str, token: str, vector: str, k: int) -> None:
     headers = {"Authorization": f"Bearer {token}"}
     floats = [float(x) for x in vector.split(',') if x.strip()]
-    params = [("vector", str(v)) for v in floats] + [("k", str(k))]
-    resp = httpx.get(f"{api_url}/vectors/search", params=params, headers=headers)
+    params_list: list[tuple[str, str | int | float | bool | None]] = [
+        ("vector", str(v)) for v in floats
+    ] + [("k", k)]
+    params = QueryParams(params_list)
+    resp = httpx.get(
+        f"{api_url}/vectors/search", params=params, headers=headers
+    )
     resp.raise_for_status()
     print(json.dumps(resp.json(), indent=2))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ presidio-anonymizer = "^2.2.358"
 spacy = "^3.8.7"
 prometheus-client = "^0.22.1"
 watchdog = "^2.3"
+sse-starlette = "^0.6"
+fastapi-limiter = "^0.1"
 
 
 
@@ -38,6 +40,7 @@ ruff = "*"
 mypy = "*"
 pytest = "*"
 pytest-cov = "*"
+fakeredis = "*"
 httpx = "*"
 pre-commit = "*"
 poetry-plugin-export = "^1.9.0"

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -6,11 +6,17 @@ import os
 import logging
 import time
 from typing import Any, Dict, List, Callable, Awaitable, cast
+import asyncio
 
 from .config import settings
 from .logging_utils import configure_logging
 from fastapi import Depends, FastAPI, HTTPException, Header, Query, Request
 from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
+from fastapi_limiter import FastAPILimiter
+from fastapi_limiter.depends import RateLimiter
+import redis.asyncio as redis
+from collections import defaultdict
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from .metrics import REQUEST_COUNT, REQUEST_LATENCY
@@ -35,6 +41,44 @@ app = FastAPI(
     version="0.1.0",
     description="HTTP API for the Universal Memory Engine.",
 )
+
+
+class _MemoryRedis:
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = defaultdict(int)
+
+    async def script_load(self, _: str) -> str:
+        return "mem"
+
+    async def evalsha(self, __: str, _k: int, key: str, limit: str, _exp: str) -> int:
+        lim = int(limit)
+        if self.counts[key] >= lim:
+            return 1
+        self.counts[key] += 1
+        return 0
+
+    async def ping(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.counts.clear()
+
+
+@app.on_event("startup")
+async def _init_limiter() -> None:
+    """Initialize rate limiting using Redis or an in-memory fallback."""
+    url = os.getenv("UME_RATE_LIMIT_REDIS")
+    if url:
+        try:
+            redis_client = redis.from_url(
+                url, encoding="utf-8", decode_responses=True
+            )
+            await redis_client.ping()
+        except Exception:  # pragma: no cover - connection issue
+            redis_client = _MemoryRedis()
+    else:
+        redis_client = _MemoryRedis()
+    await FastAPILimiter.init(redis_client)
 
 
 
@@ -210,6 +254,30 @@ def api_constrained_path(
         req.since_timestamp,
     )
     return {"path": path}
+
+
+@app.get("/analytics/path/stream")
+async def api_constrained_path_stream(
+    source: str = Query(...),
+    target: str = Query(...),
+    max_depth: int | None = Query(None),
+    edge_label: str | None = Query(None),
+    since_timestamp: int | None = Query(None),
+    _: None = Depends(require_token),
+    graph: IGraphAdapter = Depends(get_graph),
+    __: None = Depends(RateLimiter(times=2, seconds=1)),
+) -> EventSourceResponse:
+    """Stream path nodes one by one as an SSE feed."""
+
+    async def _gen() -> Any:
+        path = graph.constrained_path(
+            source, target, max_depth, edge_label, since_timestamp
+        )
+        for node in path:
+            yield {"data": node}
+            await asyncio.sleep(0)
+
+    return EventSourceResponse(_gen())
 
 
 @app.post("/analytics/subgraph")

--- a/tests/test_dev_log_watcher.py
+++ b/tests/test_dev_log_watcher.py
@@ -1,4 +1,4 @@
-from types import SimpleNamespace
+from watchdog.events import FileModifiedEvent
 import json
 
 from ume.watchers.dev_log_watcher import DevLogHandler
@@ -14,8 +14,8 @@ def test_handler_produces_event(tmp_path) -> None:
 
     handler = DevLogHandler(Producer())
 
-    fake_event = SimpleNamespace(src_path=str(tmp_path / "file.txt"), is_directory=False)
-    handler.on_modified(fake_event)  # type: ignore[arg-type]
+    fake_event = FileModifiedEvent(str(tmp_path / "file.txt"))
+    handler.on_modified(fake_event)
 
     assert messages
     evt = parse_event(json.loads(messages[0].decode()))

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+import time
+
+
+def setup_module(_: object) -> None:
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    g = MockGraph()
+    g.add_node("a", {})
+    g.add_node("b", {})
+    g.add_edge("a", "b", "L")
+    configure_graph(g)
+
+
+def _get(client: TestClient):
+    return client.get(
+        "/analytics/path/stream",
+        params={"source": "a", "target": "b"},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+
+
+def test_streaming_path() -> None:
+    with TestClient(app) as client:
+        res = _get(client)
+        assert res.status_code == 200
+        data = [line for line in res.iter_lines() if line.startswith("data:")]
+        assert data == ["data: a", "data: b"]
+
+
+def test_rate_limit() -> None:
+    with TestClient(app) as client:
+        _get(client)
+        _get(client)
+        res = _get(client)
+        assert res.status_code == 429
+
+
+def test_backpressure() -> None:
+    with TestClient(app) as client:
+        res = _get(client)
+        assert res.status_code == 200
+        it = (line for line in res.iter_lines() if line)
+        first = next(it)
+        assert first == "data: a"
+        time.sleep(0.05)
+        second = next(it)
+        assert second == "data: b"


### PR DESCRIPTION
## Summary
- stream analytics path results via SSE
- protect the SSE endpoint with fastapi-limiter
- provide a minimal in-memory Redis fallback
- example client demonstrating streaming
- add tests for streaming, rate limits, and backpressure
- fix mypy warning in dev log watcher test

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68581a3c46a48326b562236666b4afd2