### PR TITLE
Add Rego policy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ ID `"forbidden"`. Additional policies can be added by dropping new modules in
 `ume/plugins/alignment/` that register themselves using
 `register_plugin()`.
 
+### Rego Policy Engine
+
+If the optional `policy` extras are installed (`poetry install --with policy`),
+UME also loads any `.rego` files found in `ume/plugins/alignment/policies/` and
+evaluates them using the built-in `RegoPolicyEngine`. Policies should define
+`allow` rules under the `ume` package. Events are rejected when the query
+`data.ume.allow` does not evaluate to `true` for the event input.
+
 ## Quickstart
 
 ### Prerequisites

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ respx = "^0.22.0"
 [tool.poetry.extras]
 vector = ["faiss-gpu"]
 embedding = ["sentence-transformers"]
+policy = ["regopy"]
 
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"

--- a/src/ume/plugins/alignment/policies/deny_forbidden_node.rego
+++ b/src/ume/plugins/alignment/policies/deny_forbidden_node.rego
@@ -1,0 +1,12 @@
+package ume
+
+# Deny creating a node with id "forbidden"
+
+forbidden_node {
+    input.event_type == "CREATE_NODE"
+    input.payload.node_id == "forbidden"
+}
+
+allow {
+    not forbidden_node
+}

--- a/src/ume/plugins/alignment/rego_engine.py
+++ b/src/ume/plugins/alignment/rego_engine.py
@@ -1,0 +1,44 @@
+"""Rego-based alignment plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import AlignmentPlugin, PolicyViolationError, register_plugin
+from ...event import Event
+
+try:  # Optional dependency
+    from regopy import Interpreter as RegoInterpreter
+except Exception:  # pragma: no cover - optional dependency
+    RegoInterpreter = None
+
+
+class RegoPolicyEngine(AlignmentPlugin):
+    """Evaluate events against Rego policies."""
+
+    def __init__(self, policy_dir: str | Path, query: str = "data.ume.allow") -> None:
+        if RegoInterpreter is None:
+            raise ImportError("regopy is required for RegoPolicyEngine")
+        self._interp = RegoInterpreter()
+        self._query = query
+        self._load_policies(Path(policy_dir))
+
+    def _load_policies(self, policy_dir: Path) -> None:
+        for path in policy_dir.glob("*.rego"):
+            with path.open("r", encoding="utf-8") as f:
+                self._interp.add_module(path.name, f.read())
+
+    def validate(self, event: Event) -> None:
+        data: dict[str, Any] = event.__dict__
+        self._interp.set_input(data)
+        output = self._interp.query(self._query)
+        allowed = bool(output and output[0].expressions and output[0].expressions[0])
+        if not allowed:
+            raise PolicyViolationError(f"Event {event.event_id} denied by Rego policy")
+
+
+# Register plugin automatically if regopy is installed
+if RegoInterpreter is not None:
+    default_dir = Path(__file__).with_name("policies")
+    register_plugin(RegoPolicyEngine(default_dir))

--- a/tests/test_alignment_plugins.py
+++ b/tests/test_alignment_plugins.py
@@ -12,3 +12,16 @@ def test_forbidden_node_policy():
     )
     with pytest.raises(PolicyViolationError):
         apply_event_to_graph(event, graph)
+
+
+def test_rego_policy_engine():
+    pytest.importorskip("regopy")
+    from ume.plugins.alignment.rego_engine import RegoPolicyEngine
+    engine = RegoPolicyEngine("src/ume/plugins/alignment/policies")
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "forbidden", "attributes": {"type": "UserMemory"}},
+    )
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)


### PR DESCRIPTION
## Summary
- add `regopy` optional dependency under a new `policy` extra
- implement `RegoPolicyEngine` plugin that loads `.rego` policy files
- include a sample policy denying creation of a `forbidden` node
- describe Rego policies in README
- extend alignment plugin tests to cover the Rego engine

## Testing
- `poetry run ruff check src/ume/plugins/alignment/rego_engine.py tests/test_alignment_plugins.py`
- `poetry run mypy --config-file mypy.ini --disable-error-code import-untyped src/ume/plugins/alignment/rego_engine.py tests/test_alignment_plugins.py`
- `PYTHONPATH=src pytest -q tests/test_alignment_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_68581a53d6b48326ba7f2a49444e487a