### PR TITLE
Expand Rego policy engine

### DIFF
--- a/src/ume/plugins/alignment/policies/allow.rego
+++ b/src/ume/plugins/alignment/policies/allow.rego
@@ -1,0 +1,11 @@
+package ume
+
+# Allow an event only when no deny rules match
+
+default allow = false
+
+allow {
+    not forbidden_node
+    not admin_role_update
+    not admin_edge
+}

--- a/src/ume/plugins/alignment/policies/deny_admin_role.rego
+++ b/src/ume/plugins/alignment/policies/deny_admin_role.rego
@@ -1,0 +1,8 @@
+package ume
+
+# Deny updating a node role to "admin"
+
+admin_role_update {
+    input.event_type == "UPDATE_NODE_ATTRIBUTES"
+    input.payload.attributes.role == "admin"
+}

--- a/src/ume/plugins/alignment/policies/deny_forbidden_node.rego
+++ b/src/ume/plugins/alignment/policies/deny_forbidden_node.rego
@@ -6,7 +6,3 @@ forbidden_node {
     input.event_type == "CREATE_NODE"
     input.payload.node_id == "forbidden"
 }
-
-allow {
-    not forbidden_node
-}

--- a/src/ume/plugins/alignment/policies/extra/deny_admin_edge.rego
+++ b/src/ume/plugins/alignment/policies/extra/deny_admin_edge.rego
@@ -1,0 +1,8 @@
+package ume
+
+# Deny creating an edge from the admin node
+
+admin_edge {
+    input.event_type == "CREATE_EDGE"
+    input.node_id == "admin"
+}

--- a/tests/test_rego_policies.py
+++ b/tests/test_rego_policies.py
@@ -1,0 +1,54 @@
+import time
+import pytest
+
+from ume import Event, EventType, PolicyViolationError
+from ume.plugins.alignment.rego_engine import RegoPolicyEngine
+
+pytest.importorskip("regopy")
+
+
+@pytest.fixture()
+def engine():
+    return RegoPolicyEngine("src/ume/plugins/alignment/policies")
+
+
+def test_allow_event(engine):
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "ok", "attributes": {"type": "UserMemory"}},
+    )
+    engine.validate(event)
+
+
+def test_forbidden_node(engine):
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "forbidden", "attributes": {"type": "UserMemory"}},
+    )
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)
+
+
+def test_admin_role_update(engine):
+    event = Event(
+        event_type=EventType.UPDATE_NODE_ATTRIBUTES,
+        timestamp=int(time.time()),
+        payload={"node_id": "user1", "attributes": {"role": "admin"}},
+    )
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)
+
+
+def test_admin_edge(engine):
+    event = Event(
+        event_type=EventType.CREATE_EDGE,
+        timestamp=int(time.time()),
+        payload={},
+        node_id="admin",
+        target_node_id="node2",
+        label="related",
+    )
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)


### PR DESCRIPTION
## Summary
- enhance `RegoPolicyEngine` to load multiple paths recursively
- add several example Rego policies
- introduce tests for policy enforcement

## Testing
- `ruff check src/ume/plugins/alignment/rego_engine.py tests/test_rego_policies.py --isolated --fix`
- `mypy src/ume/plugins/alignment/rego_engine.py`
- `pytest tests/test_rego_policies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858acb8a14c8326b2b14647dee57a30