### PR TITLE
Add streaming gRPC API

### DIFF
--- a/proto/ume.proto
+++ b/proto/ume.proto
@@ -11,6 +11,11 @@ message CypherResult {
   repeated google.protobuf.Struct records = 1;
 }
 
+// Individual record for streaming Cypher results
+message CypherRecord {
+  google.protobuf.Struct record = 1;
+}
+
 message VectorSearchRequest {
   repeated float vector = 1;
   int32 k = 2;
@@ -37,6 +42,8 @@ message AuditResponse {
 
 service UME {
   rpc RunCypher(CypherQuery) returns (CypherResult);
+  // Server streaming variant of RunCypher
+  rpc StreamCypher(CypherQuery) returns (stream CypherRecord);
   rpc SearchVectors(VectorSearchRequest) returns (VectorSearchResponse);
   rpc GetAuditEntries(AuditRequest) returns (AuditResponse);
 }

--- a/src/ume/grpc_service.py
+++ b/src/ume/grpc_service.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import typing
 
 import grpc
 from google.protobuf import struct_pb2
@@ -34,6 +35,15 @@ class UMEServicer(ume_pb2_grpc.UMEServicer):
             struct.update(rec)
             result.records.append(struct)
         return result
+
+    async def StreamCypher(
+        self, request: ume_pb2.CypherQuery, context: grpc.aio.ServicerContext
+    ) -> typing.AsyncIterator[ume_pb2.CypherRecord]:
+        records = self.query_engine.execute_cypher(request.cypher)
+        for rec in records:
+            struct = struct_pb2.Struct()
+            struct.update(rec)
+            yield ume_pb2.CypherRecord(record=struct)
 
     async def SearchVectors(
         self,

--- a/src/ume_client/async_client.py
+++ b/src/ume_client/async_client.py
@@ -19,6 +19,11 @@ class AsyncUMEClient:
         response = await self._stub.RunCypher(request)
         return [dict(r) for r in response.records]
 
+    async def stream_cypher(self, cypher: str):
+        request = ume_pb2.CypherQuery(cypher=cypher)
+        async for rec in self._stub.StreamCypher(request):
+            yield dict(rec.record)
+
     async def search_vectors(self, vector: list[float], k: int = 5):
         request = ume_pb2.VectorSearchRequest(vector=vector, k=k)
         response = await self._stub.SearchVectors(request)

--- a/src/ume_client/ume_pb2.py
+++ b/src/ume_client/ume_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry2\xb7\x01\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"7\n\x0c\x43ypherRecord\x12\'\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry2\xee\x01\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x35\n\x0cStreamCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherRecord0\x01\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -36,16 +36,18 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_CYPHERQUERY']._serialized_end=77
   _globals['_CYPHERRESULT']._serialized_start=79
   _globals['_CYPHERRESULT']._serialized_end=135
-  _globals['_VECTORSEARCHREQUEST']._serialized_start=137
-  _globals['_VECTORSEARCHREQUEST']._serialized_end=185
-  _globals['_VECTORSEARCHRESPONSE']._serialized_start=187
-  _globals['_VECTORSEARCHRESPONSE']._serialized_end=222
-  _globals['_AUDITREQUEST']._serialized_start=224
-  _globals['_AUDITREQUEST']._serialized_end=253
-  _globals['_AUDITENTRY']._serialized_start=255
-  _globals['_AUDITENTRY']._serialized_end=338
-  _globals['_AUDITRESPONSE']._serialized_start=340
-  _globals['_AUDITRESPONSE']._serialized_end=389
-  _globals['_UME']._serialized_start=392
-  _globals['_UME']._serialized_end=575
+  _globals['_CYPHERRECORD']._serialized_start=137
+  _globals['_CYPHERRECORD']._serialized_end=192
+  _globals['_VECTORSEARCHREQUEST']._serialized_start=194
+  _globals['_VECTORSEARCHREQUEST']._serialized_end=242
+  _globals['_VECTORSEARCHRESPONSE']._serialized_start=244
+  _globals['_VECTORSEARCHRESPONSE']._serialized_end=279
+  _globals['_AUDITREQUEST']._serialized_start=281
+  _globals['_AUDITREQUEST']._serialized_end=310
+  _globals['_AUDITENTRY']._serialized_start=312
+  _globals['_AUDITENTRY']._serialized_end=395
+  _globals['_AUDITRESPONSE']._serialized_start=397
+  _globals['_AUDITRESPONSE']._serialized_end=446
+  _globals['_UME']._serialized_start=449
+  _globals['_UME']._serialized_end=687
 # @@protoc_insertion_point(module_scope)

--- a/src/ume_client/ume_pb2_grpc.py
+++ b/src/ume_client/ume_pb2_grpc.py
@@ -39,6 +39,11 @@ class UMEStub(object):
                 request_serializer=ume__pb2.CypherQuery.SerializeToString,
                 response_deserializer=ume__pb2.CypherResult.FromString,
                 _registered_method=True)
+        self.StreamCypher = channel.unary_stream(
+                '/ume.UME/StreamCypher',
+                request_serializer=ume__pb2.CypherQuery.SerializeToString,
+                response_deserializer=ume__pb2.CypherRecord.FromString,
+                _registered_method=True)
         self.SearchVectors = channel.unary_unary(
                 '/ume.UME/SearchVectors',
                 request_serializer=ume__pb2.VectorSearchRequest.SerializeToString,
@@ -56,6 +61,13 @@ class UMEServicer(object):
 
     def RunCypher(self, request, context):
         """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def StreamCypher(self, request, context):
+        """Server streaming variant of RunCypher
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -79,6 +91,11 @@ def add_UMEServicer_to_server(servicer, server):
                     servicer.RunCypher,
                     request_deserializer=ume__pb2.CypherQuery.FromString,
                     response_serializer=ume__pb2.CypherResult.SerializeToString,
+            ),
+            'StreamCypher': grpc.unary_stream_rpc_method_handler(
+                    servicer.StreamCypher,
+                    request_deserializer=ume__pb2.CypherQuery.FromString,
+                    response_serializer=ume__pb2.CypherRecord.SerializeToString,
             ),
             'SearchVectors': grpc.unary_unary_rpc_method_handler(
                     servicer.SearchVectors,
@@ -118,6 +135,33 @@ class UME(object):
             '/ume.UME/RunCypher',
             ume__pb2.CypherQuery.SerializeToString,
             ume__pb2.CypherResult.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def StreamCypher(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(
+            request,
+            target,
+            '/ume.UME/StreamCypher',
+            ume__pb2.CypherQuery.SerializeToString,
+            ume__pb2.CypherRecord.FromString,
             options,
             channel_credentials,
             insecure,

--- a/tests/test_grpc_streaming.py
+++ b/tests/test_grpc_streaming.py
@@ -1,0 +1,64 @@
+import asyncio
+import sys
+from pathlib import Path
+import grpc
+
+base = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(base / "src" / "ume_client"))
+sys.path.insert(0, str(base / "src"))
+
+from ume_client import ume_pb2_grpc, ume_pb2  # noqa: E402
+from ume_client.async_client import AsyncUMEClient  # noqa: E402
+
+
+class DummyQE:
+    def execute_cypher(self, cypher: str):
+        return [{"n": 1}, {"n": 2}]
+
+
+class DummyStore:
+    def query(self, vector, k=5):
+        return []
+
+
+class TestServicer(ume_pb2_grpc.UMEServicer):
+    async def StreamCypher(self, request, context):
+        for rec in DummyQE().execute_cypher(request.cypher):
+            struct = ume_pb2.google_dot_protobuf_dot_struct__pb2.Struct()
+            struct.update(rec)
+            yield ume_pb2.CypherRecord(record=struct)
+
+
+async def _run_server(port_holder: list[int]):
+    server = grpc.aio.server()
+    ume_pb2_grpc.add_UMEServicer_to_server(TestServicer(), server)
+    port = server.add_insecure_port("localhost:0")
+    port_holder.append(port)
+    await server.start()
+    await server.wait_for_termination()
+
+
+async def _run_test(port: int):
+    async with AsyncUMEClient(f"localhost:{port}") as client:
+        results = []
+        async for rec in client.stream_cypher("return 1"):
+            results.append(rec)
+        assert results == [{"n": 1}, {"n": 2}]
+
+
+def test_stream_cypher():
+    port_holder: list[int] = []
+
+    async def runner():
+        server_task = asyncio.create_task(_run_server(port_holder))
+        while not port_holder:
+            await asyncio.sleep(0.01)
+        await _run_test(port_holder[0])
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+


### PR DESCRIPTION
## Summary
- introduce a StreamCypher RPC with server streaming
- expose StreamCypher implementation in UMEServicer
- regenerate gRPC client stubs
- add async streaming helper to AsyncUMEClient
- include gRPC streaming integration test

## Testing
- `ruff --isolated check tests/test_grpc_streaming.py src/ume/grpc_service.py src/ume_client/async_client.py`
- `pytest tests/test_grpc_streaming.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858acb7e8b88326b81cbe8f834e9059