### PR TITLE
Add versioned event envelope

### DIFF
--- a/src/ume/schemas/event_envelope.schema.json
+++ b/src/ume/schemas/event_envelope.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Event Envelope",
+  "description": "Wrapper including schema version and actual event object.",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Semantic version of the event schema"
+    },
+    "event": {
+      "type": "object",
+      "description": "Actual event payload"
+    }
+  },
+  "required": ["schema_version", "event"]
+}

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -15,3 +15,20 @@ def test_unknown_event_type_raises_validation_error():
 def test_validate_create_node_schema_success():
     data = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
     validate_event_dict(data)
+
+
+def test_validate_envelope_schema_success():
+    data = {
+        "schema_version": "1.0.0",
+        "event": {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}},
+    }
+    validate_event_dict(data)
+
+
+def test_validate_envelope_schema_bad_version():
+    data = {
+        "schema_version": "not-a-version",
+        "event": {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}},
+    }
+    with pytest.raises(ValidationError):
+        validate_event_dict(data)


### PR DESCRIPTION
## Summary
- add event envelope schema
- validate envelopes in `schema_utils`
- always wrap produced events with an envelope
- parse envelopes when consuming events
- test envelope validation and client envelope handling

## Testing
- `ruff check src/ume/schema_utils.py src/ume/client.py tests/test_schema_utils.py tests/test_client_module.py --config /tmp/ruff.toml`
- `mypy src/ume/schema_utils.py src/ume/client.py tests/test_schema_utils.py tests/test_client_module.py`
- `pytest -q tests/test_schema_utils.py tests/test_client_module.py`

------
https://chatgpt.com/codex/tasks/task_e_6858acb59ff483268c09b3522e557c22