### PR TITLE
Add performance test and benchmark automation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Weekly Benchmark
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+          run: 'true'
+      - name: Run benchmark
+        run: |
+          python -m ume.benchmarks --runs 3 --csv results.csv
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: results.csv
+      - name: Post to dashboard
+        env:
+          DASHBOARD_URL: ${{ secrets.DASHBOARD_URL }}
+        run: |
+          curl -X POST -F "file=@results.csv" "$DASHBOARD_URL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ spacy = "^3.8.7"
 prometheus-client = "^0.22.1"
 watchdog = "^2.3"
 grpcio = "*"
-protobuf = "*"
+
 
 
 

--- a/src/ume/benchmarks.py
+++ b/src/ume/benchmarks.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import argparse
+import csv
 import time
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Iterable, List
 
 import numpy as np
 
@@ -36,3 +39,76 @@ def benchmark_vector_store(
     avg_latency = (time.perf_counter() - start) / num_queries
 
     return {"build_time": build_time, "avg_query_latency": avg_latency}
+
+
+def run_benchmarks(
+    runs: int,
+    use_gpu: bool,
+    *,
+    dim: int = DEF_DIM,
+    num_vectors: int = DEF_NUM_VECTORS,
+    num_queries: int = DEF_QUERIES,
+    csv_path: Path | None = None,
+) -> List[Dict[str, float]]:
+    """Run the vector store benchmark ``runs`` times."""
+
+    results: List[Dict[str, float]] = []
+    for _ in range(runs):
+        res = benchmark_vector_store(
+            use_gpu, dim=dim, num_vectors=num_vectors, num_queries=num_queries
+        )
+        results.append(res)
+
+    if csv_path is not None:
+        fieldnames = ["run", "build_time", "avg_query_latency"]
+        with csv_path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for i, res in enumerate(results, 1):
+                writer.writerow({"run": i, **res})
+
+    return results
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entry point for running benchmarks."""
+
+    parser = argparse.ArgumentParser(description="VectorStore benchmark")
+    parser.add_argument("--use-gpu", action="store_true", help="Use GPU")
+    parser.add_argument("--dim", type=int, default=DEF_DIM, help="Vector dimension")
+    parser.add_argument(
+        "--num-vectors", type=int, default=DEF_NUM_VECTORS, help="Number of vectors"
+    )
+    parser.add_argument(
+        "--num-queries", type=int, default=DEF_QUERIES, help="Number of queries"
+    )
+    parser.add_argument("--runs", type=int, default=1, help="Number of runs")
+    parser.add_argument("--csv", type=Path, help="Write results to CSV")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    results = run_benchmarks(
+        args.runs,
+        args.use_gpu,
+        dim=args.dim,
+        num_vectors=args.num_vectors,
+        num_queries=args.num_queries,
+        csv_path=args.csv,
+    )
+
+    for i, res in enumerate(results, 1):
+        print(
+            f"Run {i}: build_time={res['build_time']:.3f}s, "
+            f"avg_query_latency={res['avg_query_latency']*1000:.3f}ms"
+        )
+
+    if len(results) > 1:
+        avg_build = sum(r["build_time"] for r in results) / len(results)
+        avg_latency = sum(r["avg_query_latency"] for r in results) / len(results)
+        print(
+            f"Average build_time={avg_build:.3f}s, "
+            f"avg_query_latency={avg_latency*1000:.3f}ms"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from typing import Dict
 import json
-import yaml  # type: ignore
+import yaml
 
 
 @dataclass

--- a/tests/perf/test_stream_throughput.py
+++ b/tests/perf/test_stream_throughput.py
@@ -1,0 +1,48 @@
+import json
+import os
+import time
+
+import pytest
+from testcontainers.kafka import KafkaContainer
+
+from ume.client import UMEClient
+from ume.config import Settings
+from ume.event import EventType
+
+
+class DockerSettings(Settings):
+    KAFKA_BOOTSTRAP_SERVERS: str
+    KAFKA_RAW_EVENTS_TOPIC: str = "perf_raw"
+    KAFKA_CLEAN_EVENTS_TOPIC: str = "perf_raw"
+    KAFKA_GROUP_ID: str = "perf_group"
+
+    def __init__(self, broker: str) -> None:
+        super().__init__()
+        self.KAFKA_BOOTSTRAP_SERVERS = broker
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_stream_throughput() -> None:
+    events = 10_000
+    with KafkaContainer() as kafka:
+        broker = kafka.get_bootstrap_server()
+        settings = DockerSettings(broker)
+        client = UMEClient(settings)
+        start = time.perf_counter()
+        for i in range(events):
+            msg = {
+                "event_type": EventType.CREATE_NODE.value,
+                "timestamp": i,
+                "payload": {"node_id": f"n{i}", "attributes": {"type": "UserMemory"}},
+                "node_id": f"n{i}",
+            }
+            client.producer.produce(settings.KAFKA_RAW_EVENTS_TOPIC, json.dumps(msg).encode())
+        client.producer.flush()
+        consumed = sum(1 for _ in client.consume_events(timeout=5))
+        duration = time.perf_counter() - start
+        client.close()
+    assert consumed == events
+    throughput = consumed / duration
+    assert throughput > 10_000
+    assert duration / consumed < 0.001


### PR DESCRIPTION
## Summary
- add perf test for streaming throughput using testcontainers
- extend vector store benchmark CLI with repeat and CSV options
- schedule weekly benchmark runs in CI
- fix duplicate dependency and remove unused ignore comment

## Testing
- `pre-commit run --files src/ume/benchmarks.py .github/workflows/benchmark.yml tests/perf/test_stream_throughput.py pyproject.toml src/ume/graph_schema.py`
- `pytest tests/perf/test_stream_throughput.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6858acba3f308326aa0b82768ebd26ce