### PR TITLE
Add error-path tests and enforce coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,53 +6,33 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-and-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
+      - name: Decide whether to run CI
+        id: changes
+        run: |
+          python scripts/ci_should_run.py
+          status=$?
+          if [ "$status" = 0 ]; then echo "run=true" >> "$GITHUB_OUTPUT"; else echo "run=false" >> "$GITHUB_OUTPUT"; fi
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          run: ${{ steps.changes.outputs.run }}
-
+      - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --no-interaction --no-ansi --with dev
       - name: Run pre-commit
         if: steps.changes.outputs.run == 'true'
         run: poetry run pre-commit run --all-files --show-diff-on-failure --color always
-
-      - name: Run tests
+      - name: Run tests with coverage
         if: steps.changes.outputs.run == 'true'
         env:
-          UME_DOCKER_TESTS: ${{ steps.changes.outputs.run }}
-        run: poetry run pytest
-
-  coverage:
-    runs-on: ["self-hosted", "linux"]
-    needs: test-and-lint
-    if: needs.test-and-lint.outputs.run == 'true'
-    strategy:
-      matrix:
-        python-version: ['3.12']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Fetch main
-        run: git fetch origin main --depth=1
-
-      - name: Set up Python and install dependencies
-        uses: ./.github/actions/setup-python-poetry
-        with:
-          python-version: ${{ matrix.python-version }}
-          run: 'true'
-
-      - name: Run tests with coverage
-        env:
           UME_DOCKER_TESTS: true
-
-        run: |
-          pip install . pytest pytest-cov pre-commit
-        - name: Lint and Test
-        run: |
-          pre-commit run --files tests/test_client_module.py tests/test_privacy_agent_additional.py
-          pytest --cov=ume --cov-report xml --cov-fail-under=80
+        run: poetry run pytest --cov=ume --cov-report xml --cov-fail-under=80

--- a/tests/test_privacy_agent_additional.py
+++ b/tests/test_privacy_agent_additional.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import json
 
 from ume import privacy_agent
 
@@ -18,3 +19,77 @@ def test_redact_event_payload_invalid_json(monkeypatch):
     redacted, flag = privacy_agent.redact_event_payload(payload)
     assert redacted == payload
     assert flag is False
+
+class Error:
+    def __init__(self, code):
+        self._code = code
+    def code(self):
+        return self._code
+
+class ErrorMessage:
+    def __init__(self, code):
+        self._err = Error(code)
+    def error(self):
+        return self._err
+    def value(self):
+        return b""
+
+class FakeConsumer:
+    def __init__(self, messages):
+        self._messages = messages
+    def poll(self, timeout=1.0):
+        if self._messages:
+            return self._messages.pop(0)
+        raise KeyboardInterrupt
+    def subscribe(self, topics):
+        pass
+    def close(self):
+        pass
+
+class FakeProducer:
+    def __init__(self):
+        self.produced = []
+        self.flush_calls = 0
+    def produce(self, *args, **kwargs):
+        self.produced.append(args)
+    def flush(self):
+        self.flush_calls += 1
+
+
+def setup_agent(monkeypatch, consumer, producer):
+    monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
+    monkeypatch.setattr(privacy_agent, "log_audit_entry", lambda *a, **k: None)
+    monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer())
+    monkeypatch.setattr(privacy_agent, "_ANONYMIZER", FakeAnonymizer())
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)
+    monkeypatch.setattr(privacy_agent, "BATCH_SIZE", 1)
+
+
+def test_kafka_error_is_skipped(monkeypatch):
+    consumer = FakeConsumer([ErrorMessage(123)])
+    producer = FakeProducer()
+    setup_agent(monkeypatch, consumer, producer)
+    privacy_agent.run_privacy_agent()
+    assert producer.produced == []
+    assert producer.flush_calls == 1
+
+
+def test_invalid_json_skips_message(monkeypatch):
+    msg = type("Msg", (), {"error": lambda self: None, "value": lambda self: b"{"})()
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    setup_agent(monkeypatch, consumer, producer)
+    privacy_agent.run_privacy_agent()
+    assert producer.produced == []
+
+
+def test_validation_error_skips_message(monkeypatch):
+    event = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    msg = type("Msg", (), {"error": lambda self: None, "value": lambda self: json.dumps(event).encode("utf-8")})()
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    monkeypatch.setattr(privacy_agent, "validate_event_dict", lambda data: (_ for _ in ()).throw(privacy_agent.ValidationError("bad")))
+    setup_agent(monkeypatch, consumer, producer)
+    privacy_agent.run_privacy_agent()
+    assert producer.produced == []


### PR DESCRIPTION
## Summary
- test privacy agent error conditions
- add tests for retention scheduler helper logic
- run pytest with coverage across Python 3.10–3.12

## Testing
- `poetry run pre-commit run --files tests/test_privacy_agent_additional.py tests/test_retention.py .github/workflows/ci.yml`
- `poetry run pytest tests/test_privacy_agent_additional.py tests/test_retention.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f8e2468883268edd908b3fec022c