### PR TITLE
Add Episodic and Semantic memory layers

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -26,6 +26,7 @@ from .graph_schema import GraphSchema, load_default_schema
 from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
 from .utils import ssl_config
+from .memory import EpisodicMemory, SemanticMemory
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
@@ -93,6 +94,9 @@ __all__ = [
     "VectorStore",
     "VectorStoreListener",
     "create_default_store",
+
+    "EpisodicMemory",
+    "SemanticMemory",
 
     "LLMFerry",
 

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -4,6 +4,7 @@ from .config import settings
 from .persistent_graph import PersistentGraph
 from .rbac_adapter import RoleBasedGraphAdapter
 from .vector_store import VectorStore, create_vector_store as _create_vector_store
+from .memory import EpisodicMemory, SemanticMemory
 
 from .graph_adapter import IGraphAdapter
 
@@ -26,3 +27,15 @@ def create_graph_adapter(
 def create_vector_store() -> VectorStore:
     """Create a :class:`VectorStore` configured from ``ume.config.settings``."""
     return _create_vector_store()
+
+
+def create_episodic_memory(
+    db_path: str | None = None, *, log_path: str | None = None
+) -> EpisodicMemory:
+    """Instantiate :class:`EpisodicMemory` using configuration defaults."""
+    return EpisodicMemory(db_path or settings.UME_DB_PATH, log_path=log_path)
+
+
+def create_semantic_memory(db_path: str | None = None) -> SemanticMemory:
+    """Instantiate :class:`SemanticMemory` using configuration defaults."""
+    return SemanticMemory(db_path or settings.UME_DB_PATH)

--- a/src/ume/memory/__init__.py
+++ b/src/ume/memory/__init__.py
@@ -1,0 +1,4 @@
+from .episodic import EpisodicMemory
+from .semantic import SemanticMemory
+
+__all__ = ["EpisodicMemory", "SemanticMemory"]

--- a/src/ume/memory/episodic.py
+++ b/src/ume/memory/episodic.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from ..event import Event, parse_event
+from ..processing import apply_event_to_graph
+from ..persistent_graph import PersistentGraph
+from ..snapshot import snapshot_graph_to_file, load_graph_from_file
+
+
+class EpisodicMemory:
+    """Event-sourced memory backed by :class:`PersistentGraph`."""
+
+    def __init__(self, db_path: str | None = None, log_path: str | None = None) -> None:
+        self.graph = PersistentGraph(db_path or ":memory:")
+        self.log_path = Path(log_path) if log_path else None
+
+    def record_event(self, event: Event) -> None:
+        """Apply ``event`` to the graph and append it to the log if configured."""
+        apply_event_to_graph(event, self.graph)
+        if self.log_path:
+            with self.log_path.open("a", encoding="utf-8") as f:
+                json.dump(event.__dict__, f)
+                f.write("\n")
+
+    def load_events(self, log_path: str) -> None:
+        """Replay events from ``log_path`` into the graph."""
+        path = Path(log_path)
+        if not path.is_file():
+            return
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                evt = parse_event(data)
+                apply_event_to_graph(evt, self.graph)
+
+    def get_episode(self, node_id: str) -> Optional[dict]:
+        return self.graph.get_node(node_id)
+
+    def related(self, node_id: str, label: str | None = None) -> list[str]:
+        return self.graph.find_connected_nodes(node_id, edge_label=label)
+
+    def save(self, path: str) -> None:
+        snapshot_graph_to_file(self.graph, path)
+
+    @classmethod
+    def load(cls, path: str, db_path: str | None = None, log_path: str | None = None) -> "EpisodicMemory":
+        graph = load_graph_from_file(path)
+        mem = cls(db_path=db_path, log_path=log_path)
+        mem.graph = graph
+        return mem
+
+    def close(self) -> None:
+        self.graph.close()

--- a/src/ume/memory/semantic.py
+++ b/src/ume/memory/semantic.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ..persistent_graph import PersistentGraph
+from ..snapshot import snapshot_graph_to_file, load_graph_from_file
+
+
+class SemanticMemory:
+    """Fact storage backed by :class:`PersistentGraph`."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.graph = PersistentGraph(db_path or ":memory:")
+
+    def add_fact(self, node_id: str, attributes: dict) -> None:
+        self.graph.add_node(node_id, attributes)
+
+    def relate_facts(self, source_id: str, target_id: str, label: str) -> None:
+        self.graph.add_edge(source_id, target_id, label)
+
+    def get_fact(self, node_id: str) -> Optional[dict]:
+        return self.graph.get_node(node_id)
+
+    def related_facts(self, node_id: str, label: str | None = None) -> list[str]:
+        return self.graph.find_connected_nodes(node_id, edge_label=label)
+
+    def save(self, path: str) -> None:
+        snapshot_graph_to_file(self.graph, path)
+
+    @classmethod
+    def load(cls, path: str, db_path: str | None = None) -> "SemanticMemory":
+        graph = load_graph_from_file(path)
+        mem = cls(db_path=db_path)
+        mem.graph = graph
+        return mem
+
+    def close(self) -> None:
+        self.graph.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,39 @@
+import time
+from ume import Event, EventType
+from ume.memory import EpisodicMemory, SemanticMemory
+
+
+def test_episodic_memory_save_load(tmp_path):
+    mem = EpisodicMemory(db_path=":memory:")
+    evt = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": "e1", "attributes": {"text": "hello"}},
+    )
+    mem.record_event(evt)
+    assert mem.get_episode("e1") == {"text": "hello"}
+
+    snapshot = tmp_path / "episodic.json"
+    mem.save(snapshot)
+    mem.close()
+
+    mem2 = EpisodicMemory.load(str(snapshot))
+    assert mem2.get_episode("e1") == {"text": "hello"}
+    mem2.close()
+
+
+def test_semantic_memory_save_load(tmp_path):
+    mem = SemanticMemory(db_path=":memory:")
+    mem.add_fact("f1", {"value": 1})
+    mem.relate_facts("f1", "f1", "SELF")
+    assert mem.get_fact("f1") == {"value": 1}
+    assert mem.related_facts("f1") == ["f1"]
+
+    path = tmp_path / "sem.json"
+    mem.save(path)
+    mem.close()
+
+    loaded = SemanticMemory.load(str(path))
+    assert loaded.get_fact("f1") == {"value": 1}
+    assert loaded.related_facts("f1") == ["f1"]
+    loaded.close()


### PR DESCRIPTION
## Summary
- introduce new `ume.memory` package with `EpisodicMemory` and `SemanticMemory`
- expose these classes in `ume.__init__`
- add factory helpers to build them
- unit tests for saving, loading and querying

## Testing
- `ruff check src/ume/memory/episodic.py src/ume/memory/semantic.py src/ume/__init__.py src/ume/factories.py tests/test_memory.py`
- `mypy --config-file mypy.ini src/ume/memory/episodic.py src/ume/memory/semantic.py src/ume/factories.py src/ume/__init__.py tests/test_memory.py`
- `pytest tests/test_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f8af3efc8326959ab92289947524