### PR TITLE
Add OPA policy client and support in Rego engine

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     LLM_FERRY_API_URL: str = "https://example.com/api"
     LLM_FERRY_API_KEY: str = ""
 
+    # OPA integration
+    OPA_URL: str = "http://localhost:8181"
+    OPA_TOKEN: str | None = None
+
 
 # Create a single, importable instance
 settings = Settings()

--- a/src/ume/plugins/alignment/rego_engine.py
+++ b/src/ume/plugins/alignment/rego_engine.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable
 
 from . import AlignmentPlugin, PolicyViolationError, register_plugin
 from ...event import Event
+from ...policy.opa_client import OPAClient
 
 try:  # Optional dependency
     from regopy import Interpreter as RegoInterpreter
@@ -15,21 +16,33 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 class RegoPolicyEngine(AlignmentPlugin):
-    """Evaluate events against Rego policies."""
+    """Evaluate events against Rego policies or a remote OPA service."""
 
     def __init__(
-        self, policy_paths: str | Path | Iterable[str | Path], query: str = "data.ume.allow"
+        self,
+        policy_paths: str | Path | Iterable[str | Path] | None = None,
+        query: str = "data.ume.allow",
+        *,
+        opa_client: OPAClient | None = None,
+        opa_path: str = "ume/allow",
     ) -> None:
-        if RegoInterpreter is None:
-            raise ImportError("regopy is required for RegoPolicyEngine")
-        self._interp = RegoInterpreter()
+        self._opa_client = opa_client
+        self._opa_path = opa_path
         self._query = query
-        if isinstance(policy_paths, (str, Path)):
-            paths = [Path(policy_paths)]
-        else:
-            paths = [Path(p) for p in policy_paths]
-        for path in paths:
-            self._load_policies(path)
+        if opa_client is None:
+            if RegoInterpreter is None:
+                raise ImportError(
+                    "regopy is required for RegoPolicyEngine when no OPA client is provided"
+                )
+            if policy_paths is None:
+                raise ValueError("policy_paths is required without opa_client")
+            self._interp = RegoInterpreter()
+            if isinstance(policy_paths, (str, Path)):
+                paths = [Path(policy_paths)]
+            else:
+                paths = [Path(p) for p in policy_paths]
+            for path in paths:
+                self._load_policies(path)
 
     def _load_policies(self, path: Path) -> None:
         if path.is_dir():
@@ -44,9 +57,13 @@ class RegoPolicyEngine(AlignmentPlugin):
 
     def validate(self, event: Event) -> None:
         data: dict[str, Any] = event.__dict__
-        self._interp.set_input(data)
-        output = self._interp.query(self._query)
-        allowed = bool(output and output[0].expressions and output[0].expressions[0])
+        if self._opa_client is not None:
+            result = self._opa_client.query(self._opa_path, data)
+            allowed = bool(result)
+        else:
+            self._interp.set_input(data)
+            output = self._interp.query(self._query)
+            allowed = bool(output and output[0].expressions and output[0].expressions[0])
         if not allowed:
             raise PolicyViolationError(f"Event {event.event_id} denied by Rego policy")
 

--- a/src/ume/policy/opa_client.py
+++ b/src/ume/policy/opa_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from types import TracebackType
+
+from ..config import settings
+
+
+class OPAClientError(Exception):
+    """Errors raised when communicating with the OPA server."""
+
+
+class OPAClient:
+    """Simple wrapper around the OPA HTTP API."""
+
+    def __init__(self, base_url: str | None = None, token: str | None = None) -> None:
+        self.base_url = base_url or settings.OPA_URL
+        self.token = token or settings.OPA_TOKEN
+        self._client = httpx.Client(timeout=5)
+
+    def query(self, path: str, input_data: dict[str, Any]) -> Any:
+        """Execute a policy query and return the result field."""
+        url = f"{self.base_url.rstrip('/')}/v1/data/{path.lstrip('/')}"
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        try:
+            resp = self._client.post(url, json={"input": input_data}, headers=headers)
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network errors
+            raise OPAClientError(f"OPA request failed: {exc}") from exc
+        return resp.json().get("result")
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "OPAClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/tests/test_opa_integration.py
+++ b/tests/test_opa_integration.py
@@ -1,0 +1,48 @@
+import httpx
+import pytest
+
+from ume.event import Event, EventType
+from ume.plugins.alignment.rego_engine import RegoPolicyEngine, PolicyViolationError
+from ume.policy.opa_client import OPAClient
+
+respx = pytest.importorskip("respx")
+
+
+def test_opa_client_query() -> None:
+    client = OPAClient(base_url="http://opa")
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post("http://opa/v1/data/ume/allow").mock(
+            return_value=httpx.Response(200, json={"result": True})
+        )
+        result = client.query("ume/allow", {"foo": "bar"})
+        assert route.called
+        assert result is True
+
+
+def test_rego_engine_delegates_to_opa() -> None:
+    engine = RegoPolicyEngine(policy_paths=None, opa_client=OPAClient(base_url="http://opa"))
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=0,
+        payload={"node_id": "n1", "attributes": {}},
+    )
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("http://opa/v1/data/ume/allow").mock(
+            return_value=httpx.Response(200, json={"result": True})
+        )
+        engine.validate(event)
+
+
+def test_rego_engine_opa_denied() -> None:
+    engine = RegoPolicyEngine(policy_paths=None, opa_client=OPAClient(base_url="http://opa"))
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=0,
+        payload={"node_id": "n1", "attributes": {}},
+    )
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("http://opa/v1/data/ume/allow").mock(
+            return_value=httpx.Response(200, json={"result": False})
+        )
+        with pytest.raises(PolicyViolationError):
+            engine.validate(event)


### PR DESCRIPTION
## Summary
- add `OPAClient` wrapper for querying Open Policy Agent
- extend `RegoPolicyEngine` to optionally delegate to OPA
- allow configuring OPA URL/token in `Settings`
- add tests with mocked OPA endpoint

## Testing
- `ruff check src/ume/config.py src/ume/plugins/alignment/rego_engine.py src/ume/policy/opa_client.py tests/test_opa_integration.py`
- `mypy src/ume/config.py src/ume/plugins/alignment/rego_engine.py src/ume/policy/opa_client.py tests/test_opa_integration.py`
- `pytest tests/test_opa_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f8ab7034832697cc5d27754e60f9