### PR TITLE
Add regression test for mixed Markdown and code changes

### DIFF
--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -66,3 +66,19 @@ def test_markdown_code_block_changes_trigger_ci():
         " ```",
     ]
     assert csr.code_diff_present(diff) is True
+
+
+def test_mixed_markdown_and_code_changes():
+    """Ensure a diff with docs and real code triggers CI."""
+
+    diff = [
+        "@@ -1 +1 @@",
+        "-Old docs",
+        "+Updated docs",
+        "@@ -10 +10 @@",
+        " def foo():",
+        "-    # comment",
+        "+    print('hi')",
+    ]
+
+    assert csr.code_diff_present(diff) is True


### PR DESCRIPTION
## Summary
- ensure `code_diff_present` detects real code when docs are edited alongside Python files

## Testing
- `pre-commit run --files tests/test_ci_should_run.py`
- `pytest tests/test_ci_should_run.py`


------
https://chatgpt.com/codex/tasks/task_e_685acff764b88326b2faf87df2cbb894