### PR TITLE
Add Tweet and Document Guru endpoints

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -47,6 +47,14 @@ Create an edge.
 ### DELETE `/edges/{source}/{target}/{label}`
 Delete an edge.
 
+### POST `/tweets`
+Post a tweet for the Tweet-bot and Document Guru.
+- **Body**: `{"text": "tweet text"}`
+
+### POST `/documents`
+Upload a document for Document Guru.
+- **Body**: `{"content": "text"}`
+
 ### POST `/vectors`
 Add a vector to the in-memory index.
 - **Body**: `{"id": "id", "vector": [0.0, ...]}`

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -6,6 +6,8 @@ function App() {
   const [password, setPassword] = useState('');
   const [vector, setVector] = useState('');
   const [cypher, setCypher] = useState('');
+  const [tweet, setTweet] = useState('');
+  const [documentText, setDocumentText] = useState('');
   const [queryResult, setQueryResult] = useState('');
   const [searchResult, setSearchResult] = useState('');
   const [stats, setStats] = useState(null);
@@ -82,6 +84,36 @@ function App() {
         )
       )
       .catch((err) => console.error('Search failed', err));
+  }
+
+  function postTweet() {
+    if (!tweet) return;
+    fetch('/tweets', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token,
+      },
+      body: JSON.stringify({ text: tweet }),
+    })
+      .then((res) => res.json())
+      .then(() => setTweet(''))
+      .catch((err) => console.error('Tweet failed', err));
+  }
+
+  function uploadDocument() {
+    if (!documentText) return;
+    fetch('/documents', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token,
+      },
+      body: JSON.stringify({ content: documentText }),
+    })
+      .then((res) => res.json())
+      .then(() => setDocumentText(''))
+      .catch((err) => console.error('Upload failed', err));
   }
 
   function runQuery() {
@@ -168,6 +200,28 @@ function App() {
         'button',
         { onClick: searchVectors, style: { marginLeft: '4px' } },
         'Search'
+      ),
+      React.createElement('input', {
+        placeholder: 'Tweet text',
+        value: tweet,
+        onChange: (e) => setTweet(e.target.value),
+        style: { marginLeft: '8px', width: '20%' },
+      }),
+      React.createElement(
+        'button',
+        { onClick: postTweet, style: { marginLeft: '4px' } },
+        'Tweet'
+      ),
+      React.createElement('textarea', {
+        placeholder: 'Document text',
+        value: documentText,
+        onChange: (e) => setDocumentText(e.target.value),
+        style: { marginLeft: '8px', width: '20%' },
+      }),
+      React.createElement(
+        'button',
+        { onClick: uploadDocument, style: { marginLeft: '4px' } },
+        'Upload Doc'
       ),
       React.createElement(
         'button',

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -22,6 +22,7 @@ from uuid import uuid4
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from sse_starlette.sse import EventSourceResponse
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
@@ -272,6 +273,14 @@ class EdgeCreateRequest(BaseModel):
     label: str
 
 
+class TweetCreateRequest(BaseModel):
+    text: str
+
+
+class DocumentUploadRequest(BaseModel):
+    content: str
+
+
 @app.post("/analytics/shortest_path")
 def api_shortest_path(
     req: ShortestPathRequest,
@@ -424,6 +433,28 @@ def api_delete_edge(
     """Delete an edge identified by source, target and label."""
     graph.delete_edge(source, target, label)
     return {"status": "ok"}
+
+
+@app.post("/tweets")
+def api_post_tweet(
+    req: TweetCreateRequest,
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    """Create a tweet node used by the Tweet-bot."""
+    node_id = f"tweet:{uuid4()}"
+    graph.add_node(node_id, {"text": req.text, "timestamp": int(time.time())})
+    return {"id": node_id}
+
+
+@app.post("/documents")
+def api_upload_document(
+    req: DocumentUploadRequest,
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    """Upload a document for Document Guru."""
+    node_id = f"doc:{uuid4()}"
+    graph.add_node(node_id, {"content": req.content, "timestamp": int(time.time())})
+    return {"id": node_id}
 
 
 class VectorAddRequest(BaseModel):

--- a/tests/test_document_guru.py
+++ b/tests/test_document_guru.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+@pytest.fixture
+def client_and_graph():
+    g = MockGraph()
+    configure_graph(g)
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    return TestClient(app), g
+
+
+def _token(client: TestClient) -> str:
+    return client.post(
+        "/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    ).json()["access_token"]
+
+
+def test_post_tweet(client_and_graph):
+    client, g = client_and_graph
+    token = _token(client)
+    res = client.post(
+        "/tweets",
+        json={"text": "hello"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    tweet_id = res.json()["id"]
+    assert g.get_node(tweet_id)["text"] == "hello"
+
+
+def test_upload_document(client_and_graph):
+    client, g = client_and_graph
+    token = _token(client)
+    res = client.post(
+        "/documents",
+        json={"content": "doc"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    doc_id = res.json()["id"]
+    assert g.get_node(doc_id)["content"] == "doc"


### PR DESCRIPTION
## Summary
- enable posting tweets and uploading documents via new routes
- handle tweets and documents from the demo frontend
- add unit tests for the new endpoints
- document the API changes

## Testing
- `ruff check src/ume/api.py tests/test_document_guru.py`
- `pytest -q tests/test_document_guru.py`

------
https://chatgpt.com/codex/tasks/task_e_685acfeb6f848326b85a4b42ad3babad