### PR TITLE
Add unit tests for small modules

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,37 @@
+import csv
+import importlib.util
+from pathlib import Path
+import sys
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "benchmarks.py"
+spec = importlib.util.spec_from_file_location("ume.benchmarks", module_path)
+assert spec and spec.loader
+benchmarks = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = benchmarks
+spec.loader.exec_module(benchmarks)
+
+
+def test_benchmark_vector_store_structure():
+    res = benchmarks.benchmark_vector_store(
+        use_gpu=False, dim=2, num_vectors=10, num_queries=5
+    )
+    assert set(res.keys()) == {"build_time", "avg_query_latency"}
+    assert isinstance(res["build_time"], float)
+    assert isinstance(res["avg_query_latency"], float)
+
+
+def test_run_benchmarks_csv(tmp_path):
+    csv_path = tmp_path / "out.csv"
+    results = benchmarks.run_benchmarks(
+        2,
+        use_gpu=False,
+        dim=2,
+        num_vectors=10,
+        num_queries=1,
+        csv_path=csv_path,
+    )
+    assert len(results) == 2
+    with csv_path.open() as f:
+        header = next(csv.reader(f))
+        assert header == ["run", "build_time", "avg_query_latency"]
+

--- a/tests/test_consumer_demo.py
+++ b/tests/test_consumer_demo.py
@@ -1,0 +1,66 @@
+# mypy: ignore-errors
+import json
+from types import SimpleNamespace
+import importlib.util
+from pathlib import Path
+import sys
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "consumer_demo.py"
+spec = importlib.util.spec_from_file_location("ume.consumer_demo", module_path)
+assert spec and spec.loader
+consumer_demo = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = consumer_demo
+spec.loader.exec_module(consumer_demo)
+
+
+class DummyMessage:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def error(self):
+        return None
+
+
+class DummyConsumer:
+    def __init__(self, messages):
+        self.messages = messages
+        self.closed = False
+
+    def subscribe(self, topics):
+        self.topics = topics
+
+    def poll(self, timeout=1.0):
+        if self.messages:
+            return self.messages.pop(0)
+        raise KeyboardInterrupt
+
+    def close(self):
+        self.closed = True
+
+
+def test_consumer_demo_processes_messages(monkeypatch):
+    data = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "payload": {"text": "hi"},
+        "node_id": "n1",
+    }
+    msg = DummyMessage(json.dumps(data).encode("utf-8"))
+    consumer = DummyConsumer([msg])
+    monkeypatch.setattr(consumer_demo, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(
+        consumer_demo, "KafkaError", SimpleNamespace(_PARTITION_EOF=None)
+    )
+    parsed = []
+    monkeypatch.setattr(consumer_demo, "parse_event", lambda d: parsed.append(d) or d)
+    monkeypatch.setattr(consumer_demo, "generate_embedding", lambda text: [0.0])
+
+    consumer_demo.main()
+
+    assert consumer.closed
+    assert parsed
+    assert parsed[0]["payload"]["embedding"] == [0.0]
+

--- a/tests/test_graph_queries_wrappers.py
+++ b/tests/test_graph_queries_wrappers.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+import importlib.util
+from pathlib import Path
+import sys
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "graph_queries.py"
+spec = importlib.util.spec_from_file_location("ume.graph_queries", module_path)
+assert spec and spec.loader
+gq = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = gq
+spec.loader.exec_module(gq)
+
+
+def test_graph_query_wrappers():
+    m = Mock()
+    gq.constrained_path(m, "a", "b", max_depth=2, edge_label="L", since_timestamp=5)
+    m.constrained_path.assert_called_once_with("a", "b", 2, "L", 5)
+
+    gq.subgraph(m, "s", 3, edge_label="E", since_timestamp=1)
+    m.extract_subgraph.assert_called_once_with("s", 3, "E", 1)
+
+    gq.neighbors(m, "n", edge_label="X")
+    m.find_connected_nodes.assert_called_once_with("n", "X")
+

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,29 @@
+import logging
+from unittest.mock import patch
+import importlib.util
+from pathlib import Path
+import sys
+
+import structlog
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "logging_utils.py"
+spec = importlib.util.spec_from_file_location("ume.logging_utils", module_path)
+assert spec and spec.loader
+logging_utils = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = logging_utils
+spec.loader.exec_module(logging_utils)
+configure_logging = logging_utils.configure_logging
+
+
+def test_configure_logging_json_and_console():
+    with patch("structlog.configure") as conf, patch("logging.basicConfig") as basic:
+        configure_logging(level="WARNING", json_logs=False)
+        procs = conf.call_args.kwargs["processors"]
+        assert isinstance(procs[-1], structlog.dev.ConsoleRenderer)
+        basic.assert_called_once_with(level=logging.WARNING, format="%(message)s")
+
+    with patch("structlog.configure") as conf, patch("logging.basicConfig"):
+        configure_logging(level="INFO", json_logs=True)
+        procs = conf.call_args.kwargs["processors"]
+        assert isinstance(procs[-1], structlog.processors.JSONRenderer)
+


### PR DESCRIPTION
## Summary
- add benchmark test for return structure and CSV output
- test consumer_demo event handling
- cover graph_queries wrapper methods
- check logging_utils configuration

## Testing
- `pre-commit run --files tests/test_benchmarks.py tests/test_consumer_demo.py tests/test_graph_queries_wrappers.py tests/test_logging_utils.py`
- `pytest -q tests/test_benchmarks.py tests/test_consumer_demo.py tests/test_graph_queries_wrappers.py tests/test_logging_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685acff3f340832690fbcb289f17bec0