### PR TITLE
Async orchestrator worker dispatch

### DIFF
--- a/src/ume/agent_orchestrator.py
+++ b/src/ume/agent_orchestrator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Any, Dict, List
+import asyncio
+from collections import defaultdict
+from typing import Callable, Any, Dict, List, Awaitable
 
 
 @dataclass
@@ -34,19 +36,37 @@ class AgentOrchestrator:
     def __init__(self, supervisor: Supervisor | None = None, critic: Critic | None = None) -> None:
         self.supervisor = supervisor or Supervisor()
         self.critic = critic or Critic()
-        self._workers: Dict[str, Callable[[AgentTask], Any]] = {}
+        self._workers: Dict[str, Callable[[AgentTask], Awaitable[Any]]] = {}
 
-    def register_worker(self, agent_id: str, handler: Callable[[AgentTask], Any]) -> None:
+    def register_worker(
+        self, agent_id: str, handler: Callable[[AgentTask], Awaitable[Any]]
+    ) -> None:
         """Register a worker that can execute tasks."""
         self._workers[agent_id] = handler
 
-    def execute_objective(self, objective: str) -> Dict[str, float]:
+    async def execute_objective(self, objective: str) -> Dict[str, float]:
         """Plan tasks for the objective and execute them across workers."""
-        scores: Dict[str, float] = {}
         tasks = self.supervisor.plan(objective)
-        for task in tasks:
-            for agent_id, worker in self._workers.items():
-                result = worker(task)
-                key = f"{agent_id}:{task.id}"
-                scores[key] = self.critic.score(result)
-        return scores
+
+        async def _run(
+            worker: Callable[[AgentTask], Awaitable[Any]],
+            agent_id: str,
+            task: AgentTask,
+        ) -> tuple[str, float]:
+            result = await worker(task)
+            return agent_id, self.critic.score(result)
+
+        coros = [
+            _run(worker, agent_id, task)
+            for task in tasks
+            for agent_id, worker in self._workers.items()
+        ]
+
+        scores_map: Dict[str, List[float]] = defaultdict(list)
+        for agent_id, score in await asyncio.gather(*coros):
+            scores_map[agent_id].append(score)
+
+        return {
+            agent_id: sum(values) / len(values)
+            for agent_id, values in scores_map.items()
+        }

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -1,4 +1,5 @@
 # mypy: ignore-errors
+import asyncio
 import importlib.util
 from pathlib import Path
 import sys
@@ -29,12 +30,12 @@ def test_execution_cycle() -> None:
     orchestrator = AgentOrchestrator(DummySupervisor(), DummyCritic())
     executed: list[str] = []
 
-    def worker(task: AgentTask) -> str:
+    async def worker(task: AgentTask) -> str:
         executed.append(task.payload)
         return "ok"
 
     orchestrator.register_worker("worker1", worker)
-    scores = orchestrator.execute_objective("test-task")
+    scores = asyncio.run(orchestrator.execute_objective("test-task"))
 
     assert executed == ["test-task"]
-    assert scores == {"worker1:t1": 1.0}
+    assert scores == {"worker1": 1.0}


### PR DESCRIPTION
## Summary
- refactor `AgentOrchestrator.execute_objective` to dispatch workers concurrently
- register workers with async handlers
- update orchestrator unit test for async execution

## Testing
- `ruff check src/ume/agent_orchestrator.py tests/test_agent_orchestrator.py`
- `mypy --config-file mypy.ini --disable-error-code no-redef src/ume/agent_orchestrator.py tests/test_agent_orchestrator.py`
- `pytest -q tests/test_agent_orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_685acf41e6e883269e439dc349ef87aa