### PR TITLE
Implement ontology listener

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -52,12 +52,21 @@ from .dag_executor import DAGExecutor, Task
 from .agent_orchestrator import AgentOrchestrator, Supervisor, Critic, AgentTask
 from .dag_service import DAGService
 from .reliability import score_text, filter_low_confidence
+from ._internal.listeners import register_listener
 
 try:  # Optional dependency
     from .embedding import generate_embedding
+    _EMBEDDINGS_AVAILABLE = True
 except Exception:  # pragma: no cover - optional import
+    _EMBEDDINGS_AVAILABLE = False
+
     def generate_embedding(text: str) -> list[float]:
         raise ImportError("sentence-transformers is required to generate embeddings")
+
+if _EMBEDDINGS_AVAILABLE:
+    from .ontology import OntologyListener, configure_ontology_graph
+    _ONTOLOGY_LISTENER = OntologyListener()
+    register_listener(_ONTOLOGY_LISTENER)
 
 
 __all__ = [
@@ -105,6 +114,8 @@ __all__ = [
     "filter_low_confidence",
 
     "generate_embedding",
+    "configure_ontology_graph",
+    "OntologyListener",
     "AgentTask",
     "AgentOrchestrator",
     "Supervisor",

--- a/tests/test_ontology_listener.py
+++ b/tests/test_ontology_listener.py
@@ -1,0 +1,53 @@
+import types
+import sys
+import time
+
+
+def test_listener_creates_edges(monkeypatch):
+    embed_mod = sys.modules.setdefault("ume.embedding", types.ModuleType("ume.embedding"))
+    monkeypatch.setattr(
+        embed_mod,
+        "generate_embedding",
+        lambda text: [1.0, 0.0] if "apple" in text else [0.9, 0.1],
+        raising=False,
+    )
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    neo4j_stub = sys.modules.setdefault("neo4j", types.ModuleType("neo4j"))
+    neo4j_stub.GraphDatabase = object
+    neo4j_stub.Driver = object
+    jsonschema_stub = sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+    jsonschema_stub.validate = lambda *a, **k: None
+    jsonschema_stub.ValidationError = type("VE", (Exception,), {})
+    prom = sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
+    prom.Counter = prom.Histogram = prom.Gauge = lambda *a, **k: None
+    from ume.graph import MockGraph
+    from ume.event import Event, EventType
+    from ume.processing import apply_event_to_graph
+    from ume.ontology import OntologyListener, configure_ontology_graph
+    from ume._internal.listeners import register_listener, unregister_listener
+
+    graph = MockGraph()
+    configure_ontology_graph(graph)
+    listener = OntologyListener()
+    register_listener(listener)
+
+    now = int(time.time())
+    e1 = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=now,
+        payload={"node_id": "n1", "attributes": {"text": "apple"}},
+    )
+    e2 = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=now,
+        payload={"node_id": "n2", "attributes": {"text": "banana"}},
+    )
+
+    apply_event_to_graph(e1, graph)
+    apply_event_to_graph(e2, graph)
+
+    unregister_listener(listener)
+
+    edges = graph.get_all_edges()
+    assert ("n1", "n2", "RELATES_TO") in edges or ("n2", "n1", "RELATES_TO") in edges
+


### PR DESCRIPTION
## Summary
- add `OntologyListener` to update ontology on node creation
- auto-register listener when embeddings are available
- integrate configuration helper and add tests

## Testing
- `ruff check src/ume/ontology.py src/ume/__init__.py tests/test_ontology_listener.py`
- `pytest tests/test_ontology_listener.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685acf4bcc6083269400c27465ac8a92