### PR TITLE
Fix episodic memory replay

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
-    UME_RELIABILITY_THRESHOLD: float = 0.5
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -54,7 +53,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_OAUTH_PASSWORD: str = "password"
     UME_OAUTH_ROLE: str = "AnalyticsAgent"
     UME_OAUTH_TTL: int = 3600
-    UME_API_TOKEN: str = "test-token"
 
     # API token used for test clients and simple auth
     UME_API_TOKEN: str = "secret-token"

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from typing import Dict
 import json
-import yaml  # type: ignore
+import yaml
 
 
 @dataclass

--- a/src/ume/memory/episodic.py
+++ b/src/ume/memory/episodic.py
@@ -16,6 +16,8 @@ class EpisodicMemory:
     def __init__(self, db_path: str | None = None, log_path: str | None = None) -> None:
         self.graph = PersistentGraph(db_path or ":memory:")
         self.log_path = Path(log_path) if log_path else None
+        if self.log_path and self.log_path.is_file():
+            self.load_events(str(self.log_path))
 
     def record_event(self, event: Event) -> None:
         """Apply ``event`` to the graph and append it to the log if configured."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -37,3 +37,20 @@ def test_semantic_memory_save_load(tmp_path):
     assert loaded.get_fact("f1") == {"value": 1}
     assert loaded.related_facts("f1") == ["f1"]
     loaded.close()
+
+
+def test_log_replayed_on_new_instance(tmp_path):
+    log = tmp_path / "events.log"
+    mem = EpisodicMemory(db_path=":memory:", log_path=str(log))
+    evt = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        node_id="e2",
+        payload={"node_id": "e2", "attributes": {"text": "hi"}},
+    )
+    mem.record_event(evt)
+    mem.close()
+
+    mem2 = EpisodicMemory(db_path=":memory:", log_path=str(log))
+    assert mem2.get_episode("e2") == {"text": "hi"}
+    mem2.close()


### PR DESCRIPTION
## Summary
- load events from the log when creating `EpisodicMemory`
- ensure logged events are replayed on new instance
- clean up duplicate settings and remove unused type ignore
- update tests for log replay

## Testing
- `ruff check --config pyproject.toml src/ume/memory/episodic.py tests/test_memory.py src/ume/config.py src/ume/graph_schema.py`
- `mypy --config-file mypy.ini src/ume/memory/episodic.py tests/test_memory.py src/ume/config.py src/ume/graph_schema.py`
- `pytest tests/test_memory.py -q`
- `pre-commit run --files src/ume/memory/episodic.py tests/test_memory.py src/ume/config.py src/ume/graph_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_685acf37269883269d61ed25a1c7a683