### PR TITLE
Implement reliability filtering for analytics

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -21,6 +21,7 @@ from .logging_utils import configure_logging
 from uuid import uuid4
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -289,15 +290,16 @@ def api_constrained_path(
     graph: IGraphAdapter = Depends(get_graph),
 ) -> Dict[str, Any]:
     """Find a path subject to optional depth or label constraints."""
-    path = graph.constrained_path(
+    raw_path = graph.constrained_path(
         req.source,
         req.target,
         req.max_depth,
         req.edge_label,
         req.since_timestamp,
     )
-    filtered = filter_low_confidence(path, settings.UME_RELIABILITY_THRESHOLD)
-    return {"path": filtered}
+    threshold = settings.UME_RELIABILITY_THRESHOLD
+    nodes = filter_low_confidence(raw_path, threshold)
+    return {"path": nodes}
 
 
 @app.get("/analytics/path/stream")
@@ -337,12 +339,15 @@ def api_subgraph(
         req.edge_label,
         req.since_timestamp,
     )
-    nodes = filter_low_confidence(
-        sg.get("nodes", {}).keys(), settings.UME_RELIABILITY_THRESHOLD
-    )
+    threshold = settings.UME_RELIABILITY_THRESHOLD
+    nodes = filter_low_confidence(sg.get("nodes", {}).keys(), threshold)
     sg["nodes"] = {n: sg["nodes"][n] for n in nodes}
     sg["edges"] = [
-        e for e in sg.get("edges", []) if e[0] in sg["nodes"] and e[1] in sg["nodes"]
+        e
+        for e in sg.get("edges", [])
+        if len(filter_low_confidence(e, threshold)) == len(e)
+        and e[0] in sg["nodes"]
+        and e[1] in sg["nodes"]
     ]
     return sg
 

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
-    UME_RELIABILITY_THRESHOLD: float = 0.5
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -54,7 +53,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_OAUTH_PASSWORD: str = "password"
     UME_OAUTH_ROLE: str = "AnalyticsAgent"
     UME_OAUTH_TTL: int = 3600
-    UME_API_TOKEN: str = "test-token"
 
     # API token used for test clients and simple auth
     UME_API_TOKEN: str = "secret-token"

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from typing import Dict
 import json
-import yaml  # type: ignore
+import yaml
 
 
 @dataclass

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 from ume.api import app, configure_graph
 from ume.graph import MockGraph
@@ -11,7 +12,8 @@ def _token(client: TestClient) -> str:
         "/token",
         data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
     )
-    return res.json()["access_token"]
+    token = res.json()["access_token"]
+    return str(token)
 
 
 def test_filter_low_confidence() -> None:
@@ -20,7 +22,7 @@ def test_filter_low_confidence() -> None:
     assert result == ["good"]
 
 
-def test_shortest_path_low_confidence(monkeypatch) -> None:
+def test_shortest_path_low_confidence(monkeypatch: MonkeyPatch) -> None:
     g = MockGraph()
     g.add_node("good", {})
     g.add_node("bad1", {})
@@ -38,3 +40,48 @@ def test_shortest_path_low_confidence(monkeypatch) -> None:
     )
     assert res.status_code == 200
     assert res.json()["path"] == ["good"]
+
+
+def test_constrained_path_low_confidence(monkeypatch: MonkeyPatch) -> None:
+    g = MockGraph()
+    g.add_node("good", {})
+    g.add_node("bad2", {})
+    g.add_edge("good", "bad2", "L")
+    configure_graph(g)
+
+    monkeypatch.setattr(settings, "UME_RELIABILITY_THRESHOLD", 0.9)
+
+    client = TestClient(app)
+    token = _token(client)
+    res = client.post(
+        "/analytics/path",
+        json={"source": "good", "target": "bad2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json()["path"] == ["good"]
+
+
+def test_subgraph_low_confidence(monkeypatch: MonkeyPatch) -> None:
+    g = MockGraph()
+    g.add_node("good", {})
+    g.add_node("good2", {})
+    g.add_node("bad3", {})
+    g.add_edge("good", "good2", "L")
+    g.add_edge("good", "good2", "123")
+    g.add_edge("good", "bad3", "L")
+    configure_graph(g)
+
+    monkeypatch.setattr(settings, "UME_RELIABILITY_THRESHOLD", 0.8)
+
+    client = TestClient(app)
+    token = _token(client)
+    res = client.post(
+        "/analytics/subgraph",
+        json={"start": "good", "depth": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert set(data["nodes"].keys()) == {"good", "good2"}
+    assert data["edges"] == [["good", "good2", "L"]]


### PR DESCRIPTION
## Summary
- filter low confidence nodes in `/analytics/path`
- filter out unreliable nodes and edges in `/analytics/subgraph`
- adjust regression tests for reliability filtering

## Testing
- `pre-commit run --files tests/test_reliability.py src/ume/api.py`
- `pytest tests/test_reliability.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685acf3ac9fc832694da7cea8054ec21