### PR TITLE
Add audit signing key to env example

### DIFF
--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -9,6 +9,9 @@ UME_CLI_DB=./ume.db
 # Location for audit log entries
 UME_AUDIT_LOG_PATH=./audit.log
 
+# Key used to sign audit entries. Must be changed from the default.
+UME_AUDIT_SIGNING_KEY=<your-key>
+
 # Credentials used to obtain OAuth tokens
 UME_OAUTH_USERNAME=ume
 UME_OAUTH_PASSWORD=password


### PR DESCRIPTION
## Summary
- document `UME_AUDIT_SIGNING_KEY` in `docs/ENV_EXAMPLE.md`
- clarify that a non-default signing key is required

## Testing
- *No tests run since this only updates documentation*


------
https://chatgpt.com/codex/tasks/task_e_685acfd2ed94832695a8c8c2c60adc1a