### PR TITLE
Add AngelBridge summary service

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ For current plans and eventual detailed documentation on the UME graph model, pl
 *   [**Graph Model Documentation (docs/GRAPH_MODEL.md)**](docs/GRAPH_MODEL.md)
 *   [**Graph Listener Guide (docs/GRAPH_LISTENERS.md)**](docs/GRAPH_LISTENERS.md)
 *   [**LLM Ferry (docs/LLM_FERRY.md)**](docs/LLM_FERRY.md)
+*   [**Angel Bridge (docs/ANGEL_BRIDGE.md)**](docs/ANGEL_BRIDGE.md)
 *   [**API Reference (docs/API_REFERENCE.md)**](docs/API_REFERENCE.md)
 *   [**Self-Hosted Runner Setup (docs/SELF_HOSTED_RUNNER.md)**](docs/SELF_HOSTED_RUNNER.md)
 *   [**DAGExecutor Guide (docs/DAG_EXECUTOR.md)**](docs/DAG_EXECUTOR.md)

--- a/docs/ANGEL_BRIDGE.md
+++ b/docs/ANGEL_BRIDGE.md
@@ -1,0 +1,17 @@
+# Angel Bridge
+
+`AngelBridge` consumes recent events and emits a short daily summary. This can be
+used to keep external services informed about the system's activity without
+exposing the full event stream.
+
+The implementation included here is a stub which counts events in a given
+lookback window. Real deployments might query a database or message queue and
+post the resulting summary to another service.
+
+## Configuration
+
+`AngelBridge` reads its defaults from environment variables via `Settings`:
+
+- `ANGEL_BRIDGE_LOOKBACK_HOURS` – number of hours to consider when generating the summary (defaults to `24`).
+
+These can be set in your environment or `.env` file.

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -23,6 +23,9 @@ LLM_FERRY_API_URL=https://example.com/api
 
 # API key used by LLM Ferry
 LLM_FERRY_API_KEY=
+
+# Number of hours of events to include in Angel Bridge summaries
+ANGEL_BRIDGE_LOOKBACK_HOURS=24
 ```
 
 UME requires **Python 3.10** or newer. If your system Python is older than 3.10,

--- a/src/ume/angel_bridge.py
+++ b/src/ume/angel_bridge.py
@@ -1,0 +1,46 @@
+"""Angel Bridge service for generating daily summaries from recent events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Dict, Any, List
+import logging
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class AngelBridge:
+    """Consume recent events and emit a daily summary."""
+
+    def __init__(self, lookback_hours: int | None = None) -> None:
+        self.lookback_hours = lookback_hours or settings.ANGEL_BRIDGE_LOOKBACK_HOURS
+
+    def consume_events(self) -> List[Dict[str, Any]]:
+        """Return events from the last ``lookback_hours``.
+
+        This stub implementation returns an empty list. A real implementation
+        would query an event store or database for events within the given time
+        window.
+        """
+
+        logger.debug("Consuming events for last %s hours", self.lookback_hours)
+        # TODO: fetch events from storage
+        return []
+
+    def generate_summary(self, events: Iterable[Dict[str, Any]]) -> str:
+        """Generate a text summary for the provided events."""
+        count = len(list(events))
+        today = datetime.utcnow().date()
+        return f"Summary for {today}: {count} events"
+
+    def emit_daily_summary(self) -> str:
+        """Consume events and return the summary string."""
+        events = self.consume_events()
+        summary = self.generate_summary(events)
+        logger.info(summary)
+        return summary
+
+
+__all__ = ["AngelBridge"]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
-    UME_RELIABILITY_THRESHOLD: float = 0.5
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -54,7 +53,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_OAUTH_PASSWORD: str = "password"
     UME_OAUTH_ROLE: str = "AnalyticsAgent"
     UME_OAUTH_TTL: int = 3600
-    UME_API_TOKEN: str = "test-token"
 
     # API token used for test clients and simple auth
     UME_API_TOKEN: str = "secret-token"
@@ -62,6 +60,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # LLM Ferry
     LLM_FERRY_API_URL: str = "https://example.com/api"
     LLM_FERRY_API_KEY: str = ""
+
+    # Angel Bridge
+    ANGEL_BRIDGE_LOOKBACK_HOURS: int = 24
 
     def model_post_init(self, __context: Any) -> None:  # noqa: D401
         """Validate settings after initialization."""

--- a/tests/test_angel_bridge.py
+++ b/tests/test_angel_bridge.py
@@ -1,0 +1,12 @@
+from ume.angel_bridge import AngelBridge
+
+
+class DummyBridge(AngelBridge):
+    def consume_events(self):  # type: ignore[override]
+        return [{"foo": 1}, {"foo": 2}]
+
+
+def test_summary_generation() -> None:
+    bridge = DummyBridge(lookback_hours=1)
+    summary = bridge.emit_daily_summary()
+    assert "2 events" in summary


### PR DESCRIPTION
## Summary
- create `AngelBridge` service with stub summary generation
- expose `ANGEL_BRIDGE_LOOKBACK_HOURS` setting
- document the new service and update environment example
- add basic tests for summary generation
- fix duplicate configuration entries

## Testing
- `ruff check src/ume/config.py src/ume/angel_bridge.py tests/test_angel_bridge.py`
- `mypy src/ume/angel_bridge.py src/ume/config.py tests/test_angel_bridge.py`
- `pytest tests/test_angel_bridge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685acfdb37cc8326a6438938eaeb40ad