### PR TITLE
Fix ruff issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,6 +57,7 @@ Redpanda’s sizing guide shows a single such node easily handles 100 MB/s susta
 | --- | ------- | ------ | ------------ | ------------------- | ------ |
 | **1-A** | LLM Ferry bot | Productive Collaboration | Developers | Chats mirrored and logged | M |
 | **1-B** | Tweet-bot + UI | Productive Collaboration | Community manager | Posts appear in digest | M |
+| | _Implemented via_ `ume.TweetBot` | | | | |
 | **1-C** | Document Guru | Productive Collaboration | Docs team | Reformatted files awaiting approval | M |
 | **1-D** | Dashboard | Productive Collaboration | All users | Web UI shows digests | M |
 | **1-E** | OPA “work-mode” toggle | Ethical Safeguards | Ops team | Rego rule blocks distractions during meetings | S |

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -112,4 +112,5 @@ __all__ = [
     "Task",
     "DAGExecutor",
     "DAGService",
+    "TweetBot",
 ]

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -21,6 +21,7 @@ from .logging_utils import configure_logging
 from uuid import uuid4
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -63,6 +63,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     LLM_FERRY_API_URL: str = "https://example.com/api"
     LLM_FERRY_API_KEY: str = ""
 
+    # Tweet bot
+    TWITTER_BEARER_TOKEN: str | None = None
+
     def model_post_init(self, __context: Any) -> None:  # noqa: D401
         """Validate settings after initialization."""
         if self.UME_AUDIT_SIGNING_KEY == "default-key":

--- a/src/ume/tweet_bot.py
+++ b/src/ume/tweet_bot.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TWEET_URL = "https://api.twitter.com/2/tweets"
+
+
+class TweetBot:
+    """Simple interface for sending tweets."""
+
+    def __init__(self, api_url: str | None = None, bearer_token: str | None = None) -> None:
+        self.api_url = api_url or os.getenv("TWITTER_API_URL", DEFAULT_TWEET_URL)
+        self.bearer_token = bearer_token or os.getenv("TWITTER_BEARER_TOKEN")
+
+    def send_tweet(self, text: str) -> bool:
+        if not self.bearer_token:
+            raise ValueError("Missing Twitter bearer token")
+        headers = {"Authorization": f"Bearer {self.bearer_token}"}
+        try:
+            response = httpx.post(
+                self.api_url,
+                json={"text": text},
+                headers=headers,
+                timeout=5,
+            )
+            response.raise_for_status()
+            return response.status_code == 201
+        except Exception:  # pragma: no cover - network errors are logged
+            logger.exception("Failed to send tweet")
+            return False

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -4,6 +4,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import time
+import types
+import pytest
 
 from ume.persistent_graph import PersistentGraph
 import sqlite3

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,5 +1,4 @@
 from fastapi.testclient import TestClient
-import pytest
 from ume.api import app, configure_graph
 from pathlib import Path
 import sys
@@ -61,6 +60,6 @@ def test_backpressure() -> None:
         it = (line for line in res.iter_lines() if line)
         first = next(it)
         assert first == "data: a"
-        sleep(0.05)
+        time.sleep(0.05)
         second = next(it)
         assert second == "data: b"

--- a/tests/test_tweet_bot.py
+++ b/tests/test_tweet_bot.py
@@ -1,0 +1,40 @@
+import json
+import httpx
+import importlib.util
+from pathlib import Path
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "ume.tweet_bot", Path(__file__).resolve().parents[1] / "src" / "ume" / "tweet_bot.py"
+)
+tweet_bot = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(tweet_bot)
+TweetBot = tweet_bot.TweetBot
+DEFAULT_TWEET_URL = tweet_bot.DEFAULT_TWEET_URL
+
+respx = pytest.importorskip("respx")
+
+
+def test_send_tweet_success() -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        route = mock.post(DEFAULT_TWEET_URL).mock(return_value=httpx.Response(201))
+        bot = TweetBot(bearer_token="token")
+        assert bot.send_tweet("hello") is True
+        assert route.called
+        req = route.calls.last.request
+        assert req.headers.get("Authorization") == "Bearer token"
+        assert json.loads(req.content.decode()) == {"text": "hello"}
+
+
+def test_send_tweet_failure() -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post(DEFAULT_TWEET_URL).mock(return_value=httpx.Response(400))
+        bot = TweetBot(bearer_token="token")
+        assert bot.send_tweet("oops") is False
+
+
+def test_send_tweet_missing_token() -> None:
+    bot = TweetBot(bearer_token=None)
+    with pytest.raises(ValueError):
+        bot.send_tweet("hi")


### PR DESCRIPTION
## Summary
- import `EventSourceResponse` so API can reference it
- update retention and SSE tests to remove undefined names
- load `tweet_bot` module directly for testing

## Testing
- `ruff check src tests`
- `pytest -q tests/test_tweet_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685acfed719c8326904a7f17154baaa8