### PR TITLE
Add remote OPA support

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -95,6 +95,8 @@ below lists all available variables and their default values.
 | `KAFKA_CLIENT_KEY` | *(unset)* | Client key for Kafka TLS. |
 | `LLM_FERRY_API_URL` | `https://example.com/api` | Endpoint for the `LLMFerry` listener. |
 | `LLM_FERRY_API_KEY` | *(unset)* | API key used by `LLMFerry` for authentication. |
+| `UME_OPA_URL` | *(unset)* | Base URL of a remote OPA server used by `RegoPolicyEngine`. |
+| `UME_OPA_TOKEN` | *(unset)* | Bearer token sent with OPA requests. |
 
 `UME_RATE_LIMIT_REDIS` may be set to a Redis URL to enable shared rate limiting.
 If unset, the API uses an in-memory limiter.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1170,8 +1170,7 @@ version = "0.1.6"
 description = "A request rate limiter for fastapi"
 optional = false
 python-versions = ">=3.9,<4.0"
-groups = ["main"]
-
+groups = ["main", "dev"]
 files = [
     {file = "fastapi_limiter-0.1.6-py3-none-any.whl", hash = "sha256:2e53179a4208b8f2c8795e38bb001324d3dc37d2800ff49fd28ec5caabf7a240"},
     {file = "fastapi_limiter-0.1.6.tar.gz", hash = "sha256:6f5fde8efebe12eb33861bdffb91009f699369a3c2862cdc7c1d9acf912ff443"},
@@ -1589,7 +1588,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1601,7 +1600,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1623,7 +1622,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -3531,8 +3530,7 @@ version = "6.2.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-
+groups = ["main", "dev"]
 files = [
     {file = "redis-6.2.0-py3-none-any.whl", hash = "sha256:c8ddf316ee0aab65f04a11229e94a64b2618451dab7a67cb2f77eb799d872d5e"},
     {file = "redis-6.2.0.tar.gz", hash = "sha256:e821f129b75dde6cb99dd35e5c76e8c49512a5a0d8dfdc560b2fbd44b85ca977"},
@@ -5121,5 +5119,4 @@ vector = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "59cfe3321aaecb5b96ed544657bed3c76170f8338f8fc5a11913b9e7fa569b52"
-
+content-hash = "ed75edccb7a6d0a22a02ec3ad16cdafd256a74802021ee89c00d88fb86608c03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ redis = "*"
 fastapi-limiter = "*"
 sse-starlette = "*"
 python-multipart = "*"
+httpx = "*"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -57,6 +57,10 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # API token used for test clients and simple auth
 
+    # Remote OPA configuration
+    OPA_URL: str | None = None
+    OPA_TOKEN: str | None = None
+
     # LLM Ferry
     LLM_FERRY_API_URL: str = "https://example.com/api"
     LLM_FERRY_API_KEY: str = ""

--- a/src/ume/plugins/alignment/rego_engine.py
+++ b/src/ume/plugins/alignment/rego_engine.py
@@ -27,16 +27,20 @@ class RegoPolicyEngine(AlignmentPlugin):
         opa_client: OPAClient | None = None,
         opa_path: str = "ume/allow",
     ) -> None:
+        if opa_client is None and settings.OPA_URL:
+            opa_client = OPAClient(base_url=settings.OPA_URL, token=settings.OPA_TOKEN)
+
         self._opa_client = opa_client
         self._opa_path = opa_path
         self._query = query
-        if opa_client is None:
+
+        if self._opa_client is None:
             if RegoInterpreter is None:
                 raise ImportError(
                     "regopy is required for RegoPolicyEngine when no OPA client is provided"
                 )
             if policy_paths is None:
-                raise ValueError("policy_paths is required without opa_client")
+                raise ValueError("policy_paths is required without opa_client or OPA_URL")
             self._interp = RegoInterpreter()
             if isinstance(policy_paths, (str, Path)):
                 paths = [Path(policy_paths)]

--- a/src/ume/policy/opa_client.py
+++ b/src/ume/policy/opa_client.py
@@ -17,7 +17,10 @@ class OPAClient:
     """Simple wrapper around the OPA HTTP API."""
 
     def __init__(self, base_url: str | None = None, token: str | None = None) -> None:
-        self.base_url = base_url or settings.OPA_URL
+        resolved_url = base_url or settings.OPA_URL
+        if not resolved_url:
+            raise ValueError("OPA base URL must be provided")
+        self.base_url = resolved_url
         self.token = token or settings.OPA_TOKEN
         self._client = httpx.Client(timeout=5)
 

--- a/tests/test_opa_server.py
+++ b/tests/test_opa_server.py
@@ -1,0 +1,76 @@
+import shutil
+import socket
+import subprocess
+import time
+
+import httpx
+import pytest
+
+from ume.event import Event, EventType
+from ume.plugins.alignment.rego_engine import RegoPolicyEngine
+from ume.plugins.alignment import PolicyViolationError
+from ume.config import settings
+
+
+from typing import cast
+
+
+def _get_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        return cast(int, s.getsockname()[1])
+
+
+@pytest.fixture(scope="session")
+def opa_server(tmp_path_factory):
+    opa_bin = shutil.which("opa")
+    if not opa_bin:
+        pytest.skip("OPA binary not available")
+    assert opa_bin is not None
+    port = _get_free_port()
+    data_dir = tmp_path_factory.mktemp("opa")
+    proc = subprocess.Popen([
+        opa_bin,
+        "run",
+        "--server",
+        "--addr",
+        f"localhost:{port}",
+        str(data_dir),
+    ])
+    url = f"http://localhost:{port}"
+    for _ in range(20):
+        try:
+            httpx.get(f"{url}/health")
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        proc.terminate()
+        pytest.skip("OPA server failed to start")
+    yield url
+    proc.terminate()
+    proc.wait()
+
+
+def test_remote_opa_allows_event(opa_server, monkeypatch):
+    policy = """package ume
+default allow = true
+"""
+    httpx.put(f"{opa_server}/v1/policies/test", content=policy)
+    monkeypatch.setattr(settings, "OPA_URL", opa_server, raising=False)
+    engine = RegoPolicyEngine(policy_paths=None)
+    event = Event(event_type=EventType.CREATE_NODE, timestamp=0, payload={"node_id": "n1", "attributes": {}})
+    engine.validate(event)
+
+
+def test_remote_opa_denies_event(opa_server, monkeypatch):
+    policy = """package ume
+default allow = false
+"""
+    httpx.put(f"{opa_server}/v1/policies/test", content=policy)
+    monkeypatch.setattr(settings, "OPA_URL", opa_server, raising=False)
+    engine = RegoPolicyEngine(policy_paths=None)
+    event = Event(event_type=EventType.CREATE_NODE, timestamp=0, payload={"node_id": "n1", "attributes": {}})
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)
+


### PR DESCRIPTION
## Summary
- allow `RegoPolicyEngine` to query a remote OPA server when `settings.OPA_URL` is set
- document remote OPA configuration
- add integration tests that spin up OPA and check allow/deny
- add `OPA_URL` and `OPA_TOKEN` config vars and validate `OPAClient` initialization

## Testing
- `pre-commit run --files docs/CONFIG_TEMPLATES.md src/ume/plugins/alignment/rego_engine.py tests/test_opa_server.py src/ume/config.py pyproject.toml src/ume/policy/opa_client.py`
- `pytest -q tests/test_opa_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685b5617411883269548f204951f8f49