### PR TITLE
Configure MyPy and add type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
           poetry run pytest --cov=src/ume --cov-report=xml --cov-report=term-missing tests/
           # Generates term-missing report for console and xml for potential external tools
 
+      - name: Type check with MyPy
+        run: |
+          poetry run mypy --config-file pyproject.toml src/ume
+
       - name: Lint with Ruff
         run: |
           poetry run ruff check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ mypy = "*"
 pytest = "*"
 pytest-cov = "*"
 
+[tool.mypy]
+python_version = "3.12"
+check_untyped_defs = true
+
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"
 

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -66,7 +66,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         EventError: If required fields are missing or have incorrect types for the given event_type.
     """
     # Basic presence and type checks for common fields
-    missing_base_fields = []
+    missing_base_fields: list[str] = []
     if "event_type" not in data:
         missing_base_fields.append("event_type")
     if "timestamp" not in data:
@@ -76,24 +76,24 @@ def parse_event(data: Dict[str, Any]) -> Event:
             f"Missing required event fields: {', '.join(missing_base_fields)}"
         )
 
-    event_type = data["event_type"]
+    event_type: str = data["event_type"]
     if not isinstance(event_type, str):
         raise EventError(
             f"Invalid type for 'event_type': expected str, got {type(event_type).__name__}"
         )
 
-    timestamp = data["timestamp"]
+    timestamp: int = data["timestamp"]
     if not isinstance(timestamp, int):
         raise EventError(
             f"Invalid type for 'timestamp': expected int, got {type(timestamp).__name__}"
         )
 
     # Get potential values, to be validated by type-specific logic or used if optional
-    node_id_val = data.get("node_id")
-    target_node_id_val = data.get("target_node_id")
-    label_val = data.get("label")
+    node_id_val: Optional[str] = data.get("node_id")
+    target_node_id_val: Optional[str] = data.get("target_node_id")
+    label_val: Optional[str] = data.get("label")
     # Default payload to {} if not present; specific event types might require it later
-    payload_val = data.get("payload", {})
+    payload_val: Dict[str, Any] = data.get("payload", {})
 
     if event_type in ["CREATE_NODE", "UPDATE_NODE_ATTRIBUTES"]:
         if "node_id" not in data:  # Must be present in data

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -169,7 +169,7 @@ class MockGraph(IGraphAdapter):
         if not self.node_exists(node_id):
             raise ProcessingError(f"Node '{node_id}' not found.")
 
-        connected_nodes = []
+        connected_nodes: List[str] = []
         for src, target, lbl in self._edges:
             if src == node_id:
                 if edge_label is None or lbl == edge_label:
@@ -199,5 +199,7 @@ class MockGraph(IGraphAdapter):
             "edges" maps to a list of all edges, where each edge is a tuple
             (source_node_id, target_node_id, label).
         """
-        node_copies = {k: v.copy() for k, v in self._nodes.items()}
+        node_copies: Dict[str, Dict[str, Any]] = {
+            k: v.copy() for k, v in self._nodes.items()
+        }
         return {"nodes": node_copies, "edges": list(self._edges)}


### PR DESCRIPTION
## Summary
- configure MyPy in `pyproject.toml`
- annotate `event.py` and `graph.py`
- run MyPy in CI

## Testing
- `poetry run ruff check src tests`
- `poetry run pytest -q tests`
- `poetry run mypy --config-file pyproject.toml src/ume`


------
https://chatgpt.com/codex/tasks/task_e_685da35570848326bc96bd2f92a1cd6d