### PR TITLE
Add configurable graph adapters

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -6,6 +6,7 @@ Universal Memory Engine (UME) core package.
 from .event import Event, parse_event, EventError
 from .graph import MockGraph
 from .graph_adapter import IGraphAdapter
+from .adapters import Neo4jAdapter, LanceDBAdapter, get_adapter
 from .processing import apply_event_to_graph, ProcessingError
 from .snapshot import (
     snapshot_graph_to_file,
@@ -24,4 +25,7 @@ __all__ = [
     "snapshot_graph_to_file",
     "load_graph_from_file",  # Add this
     "SnapshotError",  # Add this
+    "Neo4jAdapter",
+    "LanceDBAdapter",
+    "get_adapter",
 ]

--- a/src/ume/adapters/__init__.py
+++ b/src/ume/adapters/__init__.py
@@ -1,0 +1,23 @@
+from typing import Dict, Type
+
+from ..graph import MockGraph
+from ..graph_adapter import IGraphAdapter
+
+from .neo4j_adapter import Neo4jAdapter
+from .lancedb_adapter import LanceDBAdapter
+
+_ADAPTERS: Dict[str, Type[IGraphAdapter]] = {
+    "mock": MockGraph,
+    "neo4j": Neo4jAdapter,
+    "lancedb": LanceDBAdapter,
+}
+
+
+def get_adapter(name: str) -> IGraphAdapter:
+    """Return an adapter instance by name."""
+    key = name.lower()
+    if key not in _ADAPTERS:
+        raise ValueError(f"Unknown adapter '{name}'")
+    return _ADAPTERS[key]()
+
+__all__ = ["Neo4jAdapter", "LanceDBAdapter", "get_adapter"]

--- a/src/ume/adapters/lancedb_adapter.py
+++ b/src/ume/adapters/lancedb_adapter.py
@@ -1,0 +1,8 @@
+from ..graph import MockGraph
+
+
+class LanceDBAdapter(MockGraph):
+    """Placeholder adapter simulating LanceDB using an in-memory graph."""
+
+    pass
+

--- a/src/ume/adapters/neo4j_adapter.py
+++ b/src/ume/adapters/neo4j_adapter.py
@@ -1,0 +1,8 @@
+from ..graph import MockGraph
+
+
+class Neo4jAdapter(MockGraph):
+    """Placeholder adapter mimicking a Neo4j backend using an in-memory graph."""
+
+    pass
+

--- a/tests/test_adapter_selection.py
+++ b/tests/test_adapter_selection.py
@@ -1,0 +1,22 @@
+import time
+from ume import Event, apply_event_to_graph
+from ume.adapters import Neo4jAdapter, LanceDBAdapter
+from ume_cli import UMEPrompt
+
+
+def test_prompt_env_adapter(monkeypatch):
+    monkeypatch.setenv("UME_GRAPH_ADAPTER", "neo4j")
+    prompt = UMEPrompt()
+    assert isinstance(prompt.graph, Neo4jAdapter)
+
+
+def test_prompt_cli_arg_adapter():
+    prompt = UMEPrompt(adapter_name="lancedb")
+    assert isinstance(prompt.graph, LanceDBAdapter)
+    event = Event(
+        event_type="CREATE_NODE",
+        timestamp=int(time.time()),
+        payload={"node_id": "n1"},
+    )
+    apply_event_to_graph(event, prompt.graph)
+    assert prompt.graph.node_exists("n1")


### PR DESCRIPTION
## Summary
- add placeholder graph adapters for Neo4j and LanceDB
- expose adapter factory utilities
- allow `ume_cli` to choose graph adapter via env var or CLI flag
- test adapter selection

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da2ed96c48326ac9694027920a62a